### PR TITLE
Add reusable Elixir CI workflow

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -238,24 +238,24 @@ jobs:
           const dialyzerOutput = process.env.DIALYZER_OUTPUT;
 
           const issueTitle = `Dialyzer warnings/errors in main branch (${context.sha.substring(0, 7)})`;
-          const issueBody = `
-          ## Dialyzer Analysis Results
-
-          **Commit:** ${context.sha}
-          **Branch:** ${context.ref}
-          **Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
-          **OTP/Elixir:** ${{ inputs.otp-version-latest }}/${{ inputs.elixir-version-latest }}
-
-          ### Output:
-          \`\`\`
-          ${dialyzerOutput}
-          \`\`\`
-
-          Please review and fix these Dialyzer warnings/errors.
-
-          ---
-          *This issue was automatically created by the Elixir CI workflow.*
-          `;
+          const issueBody = [
+            '## Dialyzer Analysis Results',
+            '',
+            `**Commit:** ${context.sha}`,
+            `**Branch:** ${context.ref}`,
+            `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            `**OTP/Elixir:** ${{ inputs.otp-version-latest }}/${{ inputs.elixir-version-latest }}`,
+            '',
+            '### Output:',
+            '```',
+            dialyzerOutput,
+            '```',
+            '',
+            'Please review and fix these Dialyzer warnings/errors.',
+            '',
+            '---',
+            '*This issue was automatically created by the Elixir CI workflow.*'
+          ].join('\n');
 
           // Check if there's already an open issue for Dialyzer
           const issues = await github.rest.issues.listForRepo({
@@ -275,17 +275,18 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: existingIssue.number,
-              body: `## New Dialyzer Issues Found
-
-              **Commit:** ${context.sha}
-              **Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
-              **OTP/Elixir:** ${{ inputs.otp-version-latest }}/${{ inputs.elixir-version-latest }}
-
-              ### Output:
-              \`\`\`
-              ${dialyzerOutput}
-              \`\`\`
-              `
+              body: [
+                '## New Dialyzer Issues Found',
+                '',
+                `**Commit:** ${context.sha}`,
+                `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                `**OTP/Elixir:** ${{ inputs.otp-version-latest }}/${{ inputs.elixir-version-latest }}`,
+                '',
+                '### Output:',
+                '```',
+                dialyzerOutput,
+                '```'
+              ].join('\n')
             });
           } else {
             // Create new issue
@@ -294,7 +295,7 @@ jobs:
               repo: context.repo.repo,
               title: issueTitle,
               body: issueBody,
-              labels: ['dialyzer', 'automated', 'bug']
+              labels: ['dialyzer', 'automated']
             });
           }
 


### PR DESCRIPTION
## Summary

Elixirプロジェクト向けのReusable CI Workflowを追加します。

Refs: smkwlab/tenbin_dns#60

## 機能

- **質設定可能なバージョン**: OTP/Elixir の LTS と Latest バージョンを入力パラメータで指定可能
- **Quality Job**: フォーマットチェック、コンパイル（警告エラー化）、Credo
- **Test Job**: LTS/Latest のマトリックスでテスト実行、カバレッジ収集
- **Dialyzer Job**: 静的解析、失敗時の自動Issue作成

## 使用方法

各リポジトリで以下のように使用します：

```yaml
name: Elixir CI

on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]

permissions:
  contents: read
  issues: write

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

jobs:
  ci:
    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@main
    with:
      coverage-threshold: 30  # optional
```

## 対象リポジトリ

このワークフローは以下のリポジトリで使用予定です：

- tenbin_dns
- tenbin_ex
- tenbin_cache
- tdig
- elixir_dnstap

## Test Plan

- [ ] このPRをマージ後、各リポジトリのワークフローを更新してテスト