### PR TITLE
ci: add actionlint workflow for validating GitHub Actions files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+# Lint Workflows
+#
+# Validates GitHub Actions workflow files using actionlint
+
+name: Lint Workflows
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**']
+  pull_request:
+    branches: [main]
+    paths: ['.github/workflows/**']
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.7


### PR DESCRIPTION
## Summary
- Add `lint.yml` workflow to validate GitHub Actions workflow files using actionlint
- Runs on push/PR to main when workflow files are changed

## Details
- Uses [actions/checkout@v4](https://github.com/actions/checkout)
- Uses [rhysd/actionlint@v1.7.7](https://github.com/rhysd/actionlint) (latest as of 2025-01-19)
- 5 minute timeout
- Read-only permissions

## Test plan
- [ ] Verify actionlint runs on this PR
- [ ] Confirm no errors in existing workflow files