### PR TITLE
fix: use escript install for mix_audit to resolve yaml_elixir dependency

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,8 +64,9 @@ jobs:
 
     - name: Run dependency security audit
       run: |
-        mix archive.install hex mix_audit --force
-        if ! mix deps.audit; then
+        mix escript.install hex mix_audit --force
+        export PATH="$HOME/.mix/escripts:$PATH"
+        if ! mix_audit; then
           echo "❌ Vulnerable dependencies found!"
           exit 1
         else


### PR DESCRIPTION
## Summary
Fix security workflow failing with `UndefinedFunctionError: function YamlElixir.read_from_file/1 is undefined`

## Problem
`mix archive.install hex mix_audit` installs mix_audit as an archive, but the `yaml_elixir` dependency is not available at runtime, causing the error:
```
** (UndefinedFunctionError) function YamlElixir.read_from_file/1 is undefined (module YamlElixir is not available)
```

## Solution
Use `mix escript.install hex mix_audit` instead, which bundles all dependencies into a standalone executable.

## Changes
- Change from `mix archive.install hex mix_audit` to `mix escript.install hex mix_audit`
- Add escript path to PATH: `$HOME/.mix/escripts`
- Call `mix_audit` directly instead of `mix deps.audit`

## Test plan
- [ ] Verify security workflow passes on all repositories