### PR TITLE
Update ai-reviewer workflow

### DIFF
--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -46,8 +46,10 @@ jobs:
     steps:
       - name: Check GEMINI_API_KEY
         id: check-key
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          if [ -z "${{ secrets.GEMINI_API_KEY }}" ]; then
+          if [ -z "$GEMINI_API_KEY" ]; then
             echo "::notice::GEMINI_API_KEY is not configured. Skipping AI review."
             echo "skip=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- Change action from `Nasubikun/ai-reviewer@v1` to `toshi0806/ai-reviewer@v1`
- Add graceful skip when `GEMINI_API_KEY` is not configured

## Changes
- Action reference updated to toshi0806 fork (maintained with updated Gemini model defaults)
- Added check step that detects missing API key and exits successfully with a notice message
- Repositories without `GEMINI_API_KEY` secret will no longer fail the workflow