### PR TITLE
feat: enable auto-merge for dependency update PRs

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -116,12 +116,28 @@ jobs:
           } >> "$GITHUB_ENV"
         fi
 
+    - name: Validate merge method
+      id: validate_merge
+      if: inputs.auto_merge
+      run: |
+        case "${{ inputs.merge_method }}" in
+          merge|squash|rebase)
+            echo "method=${{ inputs.merge_method }}" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "::error::Invalid merge method: ${{ inputs.merge_method }}. Must be merge, squash, or rebase."
+            exit 1
+            ;;
+        esac
+
     - name: Determine auto-merge status
       id: auto_merge_status
       if: steps.check_changes.outputs.changes == 'true'
       run: |
         if [ "${{ inputs.auto_merge }}" != "true" ]; then
           echo "label=disabled" >> "$GITHUB_OUTPUT"
+        elif [ "${{ steps.validate_merge.outcome }}" = "failure" ]; then
+          echo "label=skipped (invalid merge method)" >> "$GITHUB_OUTPUT"
         elif [ "${{ steps.test_run.outcome }}" != "success" ] || [ "${{ steps.format_check.outcome }}" != "success" ]; then
           echo "label=skipped (checks failed)" >> "$GITHUB_OUTPUT"
         else
@@ -151,27 +167,13 @@ jobs:
           dependencies
           automated
 
-    - name: Validate merge method
-      id: validate_merge
+    - name: Enable auto-merge
+      id: auto_merge
       if: >-
-        inputs.auto_merge &&
+        steps.validate_merge.outcome == 'success' &&
         steps.create_pr.outputs['pull-request-number'] &&
         steps.test_run.outcome == 'success' &&
         steps.format_check.outcome == 'success'
-      run: |
-        case "${{ inputs.merge_method }}" in
-          merge|squash|rebase)
-            echo "method=${{ inputs.merge_method }}" >> "$GITHUB_OUTPUT"
-            ;;
-          *)
-            echo "::error::Invalid merge method: ${{ inputs.merge_method }}. Must be merge, squash, or rebase."
-            exit 1
-            ;;
-        esac
-
-    - name: Enable auto-merge
-      id: auto_merge
-      if: steps.validate_merge.outcome == 'success'
       # continue-on-error: PR creation already succeeded; auto-merge failure
       # is reported via PR comment, not by failing the entire workflow.
       continue-on-error: true

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -28,11 +28,9 @@ on:
         default: 30
         required: false
         type: number
-      # NOTE: snake_case is intentional for auto_merge and merge_method.
-      # These inputs are used in `if:` expressions where hyphens are parsed
-      # as the subtraction operator (e.g., inputs.auto-merge → inputs.auto minus merge).
-      # The existing kebab-case inputs (otp-version, etc.) are only used in
-      # `with:` / `${{ }}` string interpolation contexts where hyphens are safe.
+      # NOTE: snake_case is intentional for auto_merge and merge_method
+      # because they are used in `if:` expressions where hyphens would be
+      # parsed as the subtraction operator.
       auto_merge:
         description: 'Enable auto-merge when tests and format pass (requires "Allow auto-merge" in repo Settings > General)'
         default: false
@@ -119,6 +117,7 @@ jobs:
     - name: Validate merge method
       id: validate_merge
       if: inputs.auto_merge
+      continue-on-error: true
       run: |
         case "${{ inputs.merge_method }}" in
           merge|squash|rebase)

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -26,6 +26,11 @@ on:
         default: 30
         required: false
         type: number
+      auto-merge:
+        description: 'Enable auto-merge when tests and format pass'
+        default: true
+        required: false
+        type: boolean
 
 permissions:
   contents: write
@@ -115,13 +120,7 @@ jobs:
           ## Test Results
           - Tests: ${{ steps.test_run.outcome }}
           - Format: ${{ steps.format_check.outcome }}
-
-          Please review the changes and ensure all tests pass before merging.
-
-          ### Checklist
-          - [ ] All tests pass
-          - [ ] No breaking changes in dependencies
-          - [ ] Security advisories addressed (if any)
+          - Auto-merge: ${{ inputs.auto-merge && steps.test_run.outcome == 'success' && steps.format_check.outcome == 'success' && 'enabled' || 'disabled (manual review required)' }}
         branch: dependency-update-${{ github.run_number }}
         delete-branch: true
         labels: |
@@ -130,11 +129,14 @@ jobs:
 
     - name: Enable auto-merge
       if: >-
+        inputs.auto-merge &&
         steps.create_pr.outputs.pull-request-number &&
         steps.test_run.outcome == 'success' &&
         steps.format_check.outcome == 'success'
+      continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        echo "Enabling auto-merge for PR #${{ steps.create_pr.outputs.pull-request-number }}"
         gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} \
           --auto --merge

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -100,6 +100,7 @@ jobs:
         fi
 
     - name: Create Pull Request
+      id: create_pr
       if: steps.check_changes.outputs.changes == 'true'
       uses: peter-evans/create-pull-request@v7
       with:
@@ -126,3 +127,14 @@ jobs:
         labels: |
           dependencies
           automated
+
+    - name: Enable auto-merge
+      if: >-
+        steps.create_pr.outputs.pull-request-number &&
+        steps.test_run.outcome == 'success' &&
+        steps.format_check.outcome == 'success'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} \
+          --auto --merge

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -29,8 +29,10 @@ on:
         required: false
         type: number
       # NOTE: snake_case is intentional for auto_merge and merge_method.
-      # Hyphens in input names are interpreted as subtraction in GitHub Actions
-      # `if:` expressions (e.g., inputs.auto-merge → inputs.auto minus merge).
+      # These inputs are used in `if:` expressions where hyphens are parsed
+      # as the subtraction operator (e.g., inputs.auto-merge → inputs.auto minus merge).
+      # The existing kebab-case inputs (otp-version, etc.) are only used in
+      # `with:` / `${{ }}` string interpolation contexts where hyphens are safe.
       auto_merge:
         description: 'Enable auto-merge when tests and format pass (requires "Allow auto-merge" in repo Settings > General)'
         default: false
@@ -164,6 +166,7 @@ jobs:
         PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
         MERGE_METHOD: ${{ steps.validate_merge.outputs.method }}
       run: |
+        set -o pipefail
         echo "Enabling auto-merge for PR #${PR_NUMBER}"
         gh pr merge "${PR_NUMBER}" \
           --auto --delete-branch "--${MERGE_METHOD}" 2>&1 | tee /tmp/auto-merge-output.txt
@@ -173,25 +176,22 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+        MERGE_METHOD: ${{ steps.validate_merge.outputs.method }}
       run: |
         if [ "${{ steps.auto_merge.outcome }}" = "success" ]; then
           gh pr comment "${PR_NUMBER}" --body "Auto-merge has been enabled successfully."
         else
           ERROR_OUTPUT=$(cat /tmp/auto-merge-output.txt 2>/dev/null || echo "unknown error")
-          gh pr comment "${PR_NUMBER}" --body "$(cat <<EOFCOMMENT
-        ⚠️ Auto-merge could not be enabled.
-
-        **Possible causes:**
-        - \"Allow auto-merge\" is not enabled in repository Settings > General
-        - The merge method (${MERGE_METHOD:-merge}) is not allowed by repository settings
-        - Insufficient token permissions
-        - Branch protection rules are blocking auto-merge
-
-        **Error output:**
-        \`\`\`
-        ${ERROR_OUTPUT}
-        \`\`\`
-        EOFCOMMENT
-          )"
+          BODY="⚠️ Auto-merge could not be enabled."
+          BODY="${BODY}"$'\n\n'"**Possible causes:**"
+          BODY="${BODY}"$'\n'"- \"Allow auto-merge\" is not enabled in repository Settings > General"
+          BODY="${BODY}"$'\n'"- The merge method (${MERGE_METHOD}) is not allowed by repository settings"
+          BODY="${BODY}"$'\n'"- Insufficient token permissions"
+          BODY="${BODY}"$'\n'"- Branch protection rules are blocking auto-merge"
+          BODY="${BODY}"$'\n\n'"**Error output:**"
+          BODY="${BODY}"$'\n'"\`\`\`"
+          BODY="${BODY}"$'\n'"${ERROR_OUTPUT}"
+          BODY="${BODY}"$'\n'"\`\`\`"
+          gh pr comment "${PR_NUMBER}" --body "${BODY}"
           echo "::warning::Auto-merge could not be enabled. See PR comment for details."
         fi

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -33,6 +33,11 @@ on:
         default: false
         required: false
         type: boolean
+      merge-method:
+        description: 'Merge method for auto-merge (merge, squash, or rebase)'
+        default: 'merge'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -122,7 +127,7 @@ jobs:
           ## Test Results
           - Tests: ${{ steps.test_run.outcome }}
           - Format: ${{ steps.format_check.outcome }}
-          - Auto-merge: ${{ inputs.auto-merge && steps.test_run.outcome == 'success' && steps.format_check.outcome == 'success' && 'requested' || 'disabled (manual review required)' }}
+          - Auto-merge: ${{ !inputs.auto-merge && 'disabled' || (steps.test_run.outcome != 'success' || steps.format_check.outcome != 'success') && 'skipped (checks failed)' || 'requested' }}
         branch: dependency-update-${{ github.run_number }}
         delete-branch: true
         labels: |
@@ -142,7 +147,7 @@ jobs:
       run: |
         echo "Enabling auto-merge for PR #${{ steps.create_pr.outputs.pull-request-number }}"
         gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} \
-          --auto --merge
+          --auto --${{ inputs.merge-method }}
 
     - name: Warn if auto-merge failed
       if: steps.auto_merge.outcome == 'failure'

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -5,7 +5,7 @@
 #     dependency-update:
 #       uses: smkwlab/.github/.github/workflows/dependency-update.yml@v1
 #       with:
-#         auto-merge: true  # optional: auto-merge when tests pass
+#         auto_merge: true  # optional: auto-merge when tests pass
 #       secrets: inherit
 
 name: Dependency Update (Reusable)
@@ -28,12 +28,12 @@ on:
         default: 30
         required: false
         type: number
-      auto-merge:
+      auto_merge:
         description: 'Enable auto-merge when tests and format pass (requires allow_auto_merge repo setting)'
         default: false
         required: false
         type: boolean
-      merge-method:
+      merge_method:
         description: 'Merge method for auto-merge (merge, squash, or rebase)'
         default: 'merge'
         required: false
@@ -127,27 +127,41 @@ jobs:
           ## Test Results
           - Tests: ${{ steps.test_run.outcome }}
           - Format: ${{ steps.format_check.outcome }}
-          - Auto-merge: ${{ !inputs.auto-merge && 'disabled' || (steps.test_run.outcome != 'success' || steps.format_check.outcome != 'success') && 'skipped (checks failed)' || 'requested' }}
+          - Auto-merge: ${{ !inputs.auto_merge && 'disabled' || (steps.test_run.outcome != 'success' || steps.format_check.outcome != 'success') && 'skipped (checks failed)' || 'requested' }}
         branch: dependency-update-${{ github.run_number }}
         delete-branch: true
         labels: |
           dependencies
           automated
 
-    - name: Enable auto-merge
-      id: auto_merge
+    - name: Validate merge method
+      id: validate_merge
       if: >-
-        inputs.auto-merge &&
+        inputs.auto_merge &&
         steps.create_pr.outputs.pull-request-number &&
         steps.test_run.outcome == 'success' &&
         steps.format_check.outcome == 'success'
+      run: |
+        case "${{ inputs.merge_method }}" in
+          merge|squash|rebase)
+            echo "method=${{ inputs.merge_method }}" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "::error::Invalid merge method: ${{ inputs.merge_method }}. Must be merge, squash, or rebase."
+            exit 1
+            ;;
+        esac
+
+    - name: Enable auto-merge
+      id: auto_merge
+      if: steps.validate_merge.outcome == 'success'
       continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "Enabling auto-merge for PR #${{ steps.create_pr.outputs.pull-request-number }}"
         gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} \
-          --auto --${{ inputs.merge-method }}
+          --auto --delete-branch --${{ steps.validate_merge.outputs.method }}
 
     - name: Warn if auto-merge failed
       if: steps.auto_merge.outcome == 'failure'

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -28,8 +28,11 @@ on:
         default: 30
         required: false
         type: number
+      # NOTE: snake_case is intentional for auto_merge and merge_method.
+      # Hyphens in input names are interpreted as subtraction in GitHub Actions
+      # `if:` expressions (e.g., inputs.auto-merge → inputs.auto minus merge).
       auto_merge:
-        description: 'Enable auto-merge when tests and format pass (requires allow_auto_merge repo setting)'
+        description: 'Enable auto-merge when tests and format pass (requires "Allow auto-merge" in repo Settings > General)'
         default: false
         required: false
         type: boolean
@@ -127,7 +130,7 @@ jobs:
           ## Test Results
           - Tests: ${{ steps.test_run.outcome }}
           - Format: ${{ steps.format_check.outcome }}
-          - Auto-merge: ${{ !inputs.auto_merge && 'disabled' || (steps.test_run.outcome != 'success' || steps.format_check.outcome != 'success') && 'skipped (checks failed)' || 'requested' }}
+          - Auto-merge: ${{ !inputs.auto_merge && 'disabled' || (steps.test_run.outcome != 'success' || steps.format_check.outcome != 'success') && 'skipped (checks failed)' || 'pending (will be confirmed by workflow)' }}
         branch: dependency-update-${{ github.run_number }}
         delete-branch: true
         labels: |
@@ -158,12 +161,37 @@ jobs:
       continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+        MERGE_METHOD: ${{ steps.validate_merge.outputs.method }}
       run: |
-        echo "Enabling auto-merge for PR #${{ steps.create_pr.outputs.pull-request-number }}"
-        gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} \
-          --auto --delete-branch --${{ steps.validate_merge.outputs.method }}
+        echo "Enabling auto-merge for PR #${PR_NUMBER}"
+        gh pr merge "${PR_NUMBER}" \
+          --auto --delete-branch "--${MERGE_METHOD}" 2>&1 | tee /tmp/auto-merge-output.txt
 
-    - name: Warn if auto-merge failed
-      if: steps.auto_merge.outcome == 'failure'
+    - name: Update PR on auto-merge result
+      if: steps.auto_merge.outcome == 'success' || steps.auto_merge.outcome == 'failure'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
       run: |
-        echo "::warning::Auto-merge could not be enabled. Check that 'Allow auto-merge' is enabled in repository settings."
+        if [ "${{ steps.auto_merge.outcome }}" = "success" ]; then
+          gh pr comment "${PR_NUMBER}" --body "Auto-merge has been enabled successfully."
+        else
+          ERROR_OUTPUT=$(cat /tmp/auto-merge-output.txt 2>/dev/null || echo "unknown error")
+          gh pr comment "${PR_NUMBER}" --body "$(cat <<EOFCOMMENT
+        ⚠️ Auto-merge could not be enabled.
+
+        **Possible causes:**
+        - \"Allow auto-merge\" is not enabled in repository Settings > General
+        - The merge method (${MERGE_METHOD:-merge}) is not allowed by repository settings
+        - Insufficient token permissions
+        - Branch protection rules are blocking auto-merge
+
+        **Error output:**
+        \`\`\`
+        ${ERROR_OUTPUT}
+        \`\`\`
+        EOFCOMMENT
+          )"
+          echo "::warning::Auto-merge could not be enabled. See PR comment for details."
+        fi

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -116,6 +116,18 @@ jobs:
           } >> "$GITHUB_ENV"
         fi
 
+    - name: Determine auto-merge status
+      id: auto_merge_status
+      if: steps.check_changes.outputs.changes == 'true'
+      run: |
+        if [ "${{ inputs.auto_merge }}" != "true" ]; then
+          echo "label=disabled" >> "$GITHUB_OUTPUT"
+        elif [ "${{ steps.test_run.outcome }}" != "success" ] || [ "${{ steps.format_check.outcome }}" != "success" ]; then
+          echo "label=skipped (checks failed)" >> "$GITHUB_OUTPUT"
+        else
+          echo "label=pending (will be confirmed by workflow)" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Create Pull Request
       id: create_pr
       if: steps.check_changes.outputs.changes == 'true'
@@ -132,7 +144,7 @@ jobs:
           ## Test Results
           - Tests: ${{ steps.test_run.outcome }}
           - Format: ${{ steps.format_check.outcome }}
-          - Auto-merge: ${{ !inputs.auto_merge && 'disabled' || (steps.test_run.outcome != 'success' || steps.format_check.outcome != 'success') && 'skipped (checks failed)' || 'pending (will be confirmed by workflow)' }}
+          - Auto-merge: ${{ steps.auto_merge_status.outputs.label }}
         branch: dependency-update-${{ github.run_number }}
         delete-branch: true
         labels: |
@@ -160,6 +172,8 @@ jobs:
     - name: Enable auto-merge
       id: auto_merge
       if: steps.validate_merge.outcome == 'success'
+      # continue-on-error: PR creation already succeeded; auto-merge failure
+      # is reported via PR comment, not by failing the entire workflow.
       continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -155,7 +155,7 @@ jobs:
       id: validate_merge
       if: >-
         inputs.auto_merge &&
-        steps.create_pr.outputs.pull-request-number &&
+        steps.create_pr.outputs['pull-request-number'] &&
         steps.test_run.outcome == 'success' &&
         steps.format_check.outcome == 'success'
       run: |
@@ -177,7 +177,7 @@ jobs:
       continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+        PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
         MERGE_METHOD: ${{ steps.validate_merge.outputs.method }}
       run: |
         set -o pipefail
@@ -189,7 +189,7 @@ jobs:
       if: steps.auto_merge.outcome == 'success' || steps.auto_merge.outcome == 'failure'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+        PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
         MERGE_METHOD: ${{ steps.validate_merge.outputs.method }}
       run: |
         if [ "${{ steps.auto_merge.outcome }}" = "success" ]; then

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -3,7 +3,9 @@
 # Usage:
 #   jobs:
 #     dependency-update:
-#       uses: smkwlab/.github/.github/workflows/dependency-update.yml@v1.1.0
+#       uses: smkwlab/.github/.github/workflows/dependency-update.yml@v1
+#       with:
+#         auto-merge: true  # optional: auto-merge when tests pass
 #       secrets: inherit
 
 name: Dependency Update (Reusable)
@@ -27,8 +29,8 @@ on:
         required: false
         type: number
       auto-merge:
-        description: 'Enable auto-merge when tests and format pass'
-        default: true
+        description: 'Enable auto-merge when tests and format pass (requires allow_auto_merge repo setting)'
+        default: false
         required: false
         type: boolean
 
@@ -120,7 +122,7 @@ jobs:
           ## Test Results
           - Tests: ${{ steps.test_run.outcome }}
           - Format: ${{ steps.format_check.outcome }}
-          - Auto-merge: ${{ inputs.auto-merge && steps.test_run.outcome == 'success' && steps.format_check.outcome == 'success' && 'enabled' || 'disabled (manual review required)' }}
+          - Auto-merge: ${{ inputs.auto-merge && steps.test_run.outcome == 'success' && steps.format_check.outcome == 'success' && 'requested' || 'disabled (manual review required)' }}
         branch: dependency-update-${{ github.run_number }}
         delete-branch: true
         labels: |
@@ -128,6 +130,7 @@ jobs:
           automated
 
     - name: Enable auto-merge
+      id: auto_merge
       if: >-
         inputs.auto-merge &&
         steps.create_pr.outputs.pull-request-number &&
@@ -140,3 +143,8 @@ jobs:
         echo "Enabling auto-merge for PR #${{ steps.create_pr.outputs.pull-request-number }}"
         gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} \
           --auto --merge
+
+    - name: Warn if auto-merge failed
+      if: steps.auto_merge.outcome == 'failure'
+      run: |
+        echo "::warning::Auto-merge could not be enabled. Check that 'Allow auto-merge' is enabled in repository settings."


### PR DESCRIPTION
## Summary
- dependency-update ワークフローに auto-merge ステップを追加
- テストとフォーマットチェックが両方成功した場合のみ、PRの auto-merge を有効化
- `peter-evans/create-pull-request` の出力からPR番号を取得して `gh pr merge --auto --merge` を実行

## 前提条件（設定済み）
- 各リポジトリで `allow_auto_merge` を有効化済み
- 各リポジトリの branch protection に `ci / Code Quality` を required status check として追加済み

## 対象リポジトリ
- tenbin_dns, tdig, tenbin_ex, tenbin_cache, elixir_dnstap

## Test plan
- [ ] ワークフローの YAML 構文が正しいことを確認
- [ ] 次回の週次実行（月曜）で auto-merge が動作することを確認
- [ ] テスト失敗時にはPRが残ることを確認