### PR TITLE
Bump latest Elixir/OTP defaults to 1.19.5 / 28.5

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -24,12 +24,12 @@ on:
         type: string
       otp-version-latest:
         description: 'Latest OTP version'
-        default: '28.2'
+        default: '28.5'
         required: false
         type: string
       elixir-version-latest:
         description: 'Latest Elixir version'
-        default: '1.19.4'
+        default: '1.19.5'
         required: false
         type: string
       dialyzer-enabled:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,12 +13,12 @@ on:
     inputs:
       otp-version:
         description: 'OTP version'
-        default: '28.2'
+        default: '28.5'
         required: false
         type: string
       elixir-version:
         description: 'Elixir version'
-        default: '1.19.4'
+        default: '1.19.5'
         required: false
         type: string
       dependency-audit-timeout:


### PR DESCRIPTION
## Summary
Reusable workflow の \"latest\" 系デフォルトバージョンを更新します。LTS（27.3.4.4 / 1.17.3）は意図的に据え置きます。

| File | Variable | Before | After |
|---|---|---|---|
| \`elixir-ci.yml\` | \`otp-version-latest\` | 28.2 | **28.5** |
| \`elixir-ci.yml\` | \`elixir-version-latest\` | 1.19.4 | **1.19.5** |
| \`security.yml\` | \`otp-version\` | 28.2 | **28.5** |
| \`security.yml\` | \`elixir-version\` | 1.19.4 | **1.19.5** |

## Impact
\`@v1\` 経由でこのリポジトリの reusable workflow を利用している全プロジェクトに、merge & \`v1\` タグ更新後に自動反映されます。
- tenbin_dns
- tdig
- tenbin_ex
- tenbin_cache
- elixir_dnstap

## Notes
- LTS バージョン（OTP 27.3.4.4 / Elixir 1.17.3）は意図的に維持
- 後続で v1.5.0 タグ付け & \`v1\` 移動タグの更新が必要

## Test plan
- [ ] このPR自体には CI 対象がないため、merge後に各プロジェクトの定期CI実行で動作確認