### PR TITLE
Pin internal preset references to v1 tag

### DIFF
--- a/elixir.json
+++ b/elixir.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>smkwlab/.github"],
+  "extends": ["github>smkwlab/.github#v1"],
   "enabledManagers": ["mix"],
   "schedule": ["before 6am on monday"],
   "lockFileMaintenance": {

--- a/latex.json
+++ b/latex.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>smkwlab/.github", "workarounds:all"],
+  "extends": ["github>smkwlab/.github#v1", "workarounds:all"],
   "schedule": ["after 9pm on sunday"],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Follow-up to #28. Pin the nested `github>smkwlab/.github` (→ `default.json`) references inside `latex.json` and `elixir.json` to the moving major tag `#v1`.

```diff
- "extends": ["github>smkwlab/.github", "workarounds:all"],
+ "extends": ["github>smkwlab/.github#v1", "workarounds:all"],
```

## Why

Consumer repos will pin to `github>smkwlab/.github:latex#v1`. However, Renovate does **not** propagate a parent preset's ref to nested presets — `github>smkwlab/.github` without a ref resolves at the default branch. Without this change, a "pinned" consumer would still pick up `default.json` (which holds the auto-merge policy) from `main` instantly, defeating the purpose of pinning.

Pinning the internal references makes the **entire** preset chain resolve at the controlled `v1` tag.

Addresses the Copilot review feedback on smkwlab/.github (unpinned preset reference) at the preset-internal layer.

## Rollout note

After this merges, the `v1` tag will be moved forward to this commit (and a `v1.6.0` release cut), so that `:latex#v1` resolves to the preset-containing, internally-pinned version. Consumer PRs (latex-environment#141, thesis-management-tools#437, latex-release-action#61) will then be updated to reference `:latex#v1`.
