### PR TITLE
Add composable npm and github-actions Renovate presets

### DIFF
--- a/github-actions.json
+++ b/github-actions.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Group and auto-merge GitHub Actions minor/patch/digest updates that pass CI",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "github actions",
+      "automerge": true,
+      "platformAutomerge": true
+    }
+  ]
+}

--- a/npm.json
+++ b/npm.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "description": "Group and auto-merge npm minor/patch/digest updates that pass CI",
+      "description": "Group and auto-merge npm minor/patch/digest and lock file maintenance updates that pass CI",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
       "groupName": "npm dependencies",

--- a/npm.json
+++ b/npm.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Group and auto-merge npm minor/patch/digest updates that pass CI",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
+      "groupName": "npm dependencies",
+      "automerge": true,
+      "platformAutomerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

npm と github-actions マネージャ向けの composable な Renovate プリセットを2つ追加します。これにより、各リポジトリは `elixir.json` を変更せずに、必要なマネージャのプリセットを組み合わせて `extends` できるようになります。

## 追加ファイル

- **`npm.json`**: npm の minor/patch/digest/lockFileMaintenance を group + auto-merge
- **`github-actions.json`**: GitHub Actions の minor/patch/digest を group + auto-merge

## 設計方針

- 既存の `latex.json` の慣習に倣い、`enabledManagers` で絞らず `packageRules` をマネージャ別に提供する add-on プリセットとして実装
- `enabledManagers` はあえて含めない（合成時に配列が後勝ちで置換されるため、利用側リポジトリのトップレベルで明示する想定）
- `schedule` / `lockFileMaintenance` などのグローバル設定は組み合わせ先プリセット（例: `elixir.json`）から継承される

## 利用例

\`\`\`json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
    "github>smkwlab/.github:elixir",
    "github>smkwlab/.github:npm",
    "github>smkwlab/.github:github-actions"
  ],
  "enabledManagers": ["mix", "npm", "github-actions"]
}
\`\`\`

## 背景

toshi0806/garoon_crawler#48 にて、ローカルの `renovate.json` の重複設定を共有設定に寄せる検討から発生しました。garoon_crawler は Playwright（npm）と GitHub Actions の更新も必要なため、これらの composable プリセットを用意します。