### PR TITLE
Add reusable Claude Code Review workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,25 @@
+# AI Reviewer (Gemini) — caller for this (.github) repository itself.
+#
+# Other repositories call the reusable workflow via
+#   uses: smkwlab/.github/.github/workflows/ai-reviewer.yml@v1
+# but for self-review we reference the reusable by local path so that each PR
+# is reviewed with its own version of the workflow (no need to wait for a tag).
+#
+# Requires the GEMINI_API_KEY secret. When it is unset (e.g. fork PRs), the
+# reusable workflow skips the review gracefully.
+
+name: AI Reviewer
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  ai-review:
+    # Skip drafts; review once the PR is ready.
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/ai-reviewer.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@
 # Usage (caller in each target repository):
 #   on:
 #     pull_request:
-#       types: [opened, synchronize, reopened]
+#       types: [opened, synchronize, reopened, ready_for_review]
 #   jobs:
 #     review:
 #       uses: smkwlab/.github/.github/workflows/claude-code-review.yml@v1
@@ -43,6 +43,11 @@ on:
         type: string
         required: false
         default: "日本語"
+      timeout_minutes:
+        description: "ジョブのタイムアウト（分）。レビューがハングした際の課金/runner 暴走を防ぐ"
+        type: number
+        required: false
+        default: 15
     secrets:
       anthropic_api_key:
         description: "Anthropic API key（caller から渡す）"
@@ -51,8 +56,11 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     # Skip drafts. Fork PRs receive no secrets, so the key check below skips
     # them gracefully instead of failing.
+    # NOTE: meant to be called from a pull_request event — the draft guard
+    # below evaluates to false (and skips) for non-PR events.
     if: github.event.pull_request.draft == false
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,92 @@
+# Reusable Claude Code Review Workflow
+#
+# Runs an automated PR review with Claude Code Action. Designed as the shared
+# org-wide review workflow to avoid GitHub Copilot premium request quota limits.
+#
+# Authentication uses a Console-issued ANTHROPIC_API_KEY (metered billing),
+# NOT a Claude Max OAuth token (subscription tokens are for personal use and
+# are not suitable for reviewing other people's PRs across repositories).
+#
+# Required secrets:
+#   - anthropic_api_key: Console-issued Anthropic API key (passed from caller)
+#
+# Usage (caller in each target repository):
+#   on:
+#     pull_request:
+#       types: [opened, synchronize, reopened]
+#   jobs:
+#     review:
+#       uses: smkwlab/.github/.github/workflows/claude-code-review.yml@v1
+#       permissions:
+#         contents: read
+#         pull-requests: write
+#         issues: write
+#       secrets:
+#         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+#       with:
+#         model: sonnet          # opus for important repos (thesis, etc.)
+#         review_language: 日本語
+
+name: Claude Code Review (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "使用モデル（sonnet / opus / haiku）"
+        type: string
+        required: false
+        default: "sonnet"
+      review_language:
+        description: "レビューコメントの言語"
+        type: string
+        required: false
+        default: "日本語"
+    secrets:
+      anthropic_api_key:
+        description: "Anthropic API key（caller から渡す）"
+        required: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Skip drafts. Fork PRs receive no secrets, so the key check below skips
+    # them gracefully instead of failing.
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Check ANTHROPIC_API_KEY
+        id: check-key
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::notice::ANTHROPIC_API_KEY is not configured (or unavailable on fork PRs). Skipping Claude review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Review
+        if: steps.check-key.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          claude_args: "--model ${{ inputs.model }}"
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            レビューコメントはすべて${{ inputs.review_language }}で記述してください。
+            各指摘には重大度（critical / warning / nit）のラベルを付けてください。
+            スタイルの好みより、バグ・セキュリティ・ロジックの問題を優先してください。

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,7 @@
 #         contents: read
 #         pull-requests: write
 #         issues: write
+#         id-token: write
 #       secrets:
 #         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 #       with:
@@ -57,6 +58,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write  # required by claude-code-action for OIDC
     steps:
       - name: Check ANTHROPIC_API_KEY
         id: check-key

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,6 +25,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write  # required by claude-code-action for OIDC
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,7 +12,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,32 @@
+# Claude Code Review — caller for this (.github) repository itself.
+#
+# Other repositories call the reusable workflow via
+#   uses: smkwlab/.github/.github/workflows/claude-code-review.yml@v1
+# but for self-review we reference the reusable by local path so that each PR
+# is reviewed with its own version of the workflow (no need to wait for a tag).
+#
+# Requires the ANTHROPIC_API_KEY secret. Fork PRs receive no secret and are
+# skipped gracefully by the reusable workflow.
+
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: ./.github/workflows/claude-code-review.yml
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      model: sonnet
+      review_language: 日本語


### PR DESCRIPTION
## 目的

GitHub Copilot review の premium request quota 超過を避けるため、**Claude Code Action による PR 自動レビュー**を smkwlab 全体の共有ワークフローとして導入する。本 PR はその第一歩となる **reusable 本体**を追加する。

## 変更内容

`​.github/workflows/claude-code-review.yml` を reusable workflow（`workflow_call`）として追加。

- **入力**: `model`（既定 `sonnet`、重要リポジトリは caller で `opus` に上書き）、`review_language`（既定 `日本語`）
- **認証**: Console 発行の `ANTHROPIC_API_KEY`（従量課金）を `anthropic_api_key` secret として caller から受け取る。Claude Max の OAuth トークンは使わない（サブスク OAuth は個人利用向けで、他者の PR 横断レビューには規約上 API キーが必要）
- **安全策**: draft PR はスキップ。fork PR では secret が渡らない GitHub 既定動作を活かし、キー欠如時はグレースフルにスキップ（既存 `ai-reviewer.yml` の慣習に合わせた `Check ANTHROPIC_API_KEY` ステップ）
- レビューコメントは日本語、各指摘に重大度（critical / warning / nit）ラベルを付与

## caller（各リポジトリ側）の使い方

```yaml
name: Claude Code Review
on:
  pull_request:
    types: [opened, synchronize, reopened]
concurrency:
  group: claude-review-${{ github.event.pull_request.number }}
  cancel-in-progress: true
jobs:
  review:
    uses: smkwlab/.github/.github/workflows/claude-code-review.yml@v1
    permissions:
      contents: read
      pull-requests: write
      issues: write
    secrets:
      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
    with:
      model: sonnet
      review_language: 日本語
```

## 管理者側で別途必要な作業（本 PR の範囲外）

- org シークレット `ANTHROPIC_API_KEY` の登録（Console で専用キー発行 → `gh secret set ... --org smkwlab`）
- `smkwlab/.github` が private の場合、Actions 設定で org 内からの reusable workflow 利用を許可

## 今後の予定（別 PR）

- caller を対象リポジトリ群へ配布する `gh` スクリプト（まず1リポジトリで検証 → 横展開）
- テスト用 PR でレビューコメントが日本語で付くことを確認
- 配布手順を README として追加

## 注意

- caller の `uses:` は安定運用のためタグ（`@v1`）固定を推奨。マージ後に `v1` タグの付与が必要
- 未信頼コードを secret 付きで実行する `pull_request_target` は使わない（プロンプトインジェクション対策）
