### PR TITLE
docs: document claude-code-review reusable workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Claude Code Action を使用して PR の自動レビューを行います。Git
 **必要な権限:** caller 側のジョブに `id-token: write`（claude-code-action の OIDC 認証で必須）に加え、`contents: read` / `pull-requests: write` / `issues: write`。
 
 **挙動:**
-- draft PR はスキップ（`ready_for_review` で起動）
+- draft PR は `ready_for_review` になるまでレビューをスキップ（`opened` / `synchronize` 時点では実行しない）
 - fork PR では secret が渡らないため安全にスキップ
 - ワークフローファイルは default ブランチに存在する必要がある（claude-code-action のセキュリティ検証）
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ smkwlab organization の共通設定および Reusable Workflows を管理する
 | `prevent-draft-merge.yml` | draft ブランチの誤マージを防止 | 卒論・ISE レポート |
 | `auto-final-merge.yml` | final-* タグ push 時に承認済み PR を自動マージ | 卒論テンプレート |
 | `ai-reviewer.yml` | Gemini AI による PR 自動レビュー | 全テンプレート |
+| `claude-code-review.yml` | Claude Code Action による PR 自動レビュー | 全テンプレート（重要リポジトリは `opus`） |
 | `notify-ml-on-pr.yml` | PR 作成時にメーリングリストへ通知 | 卒論・ISE レポート |
 
 ### HTML 関連
@@ -98,6 +99,33 @@ jobs:
     secrets: inherit
 ```
 
+#### Claude レビュー（シークレットを明示的に渡す）
+
+```yaml
+name: Claude Code Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: smkwlab/.github/.github/workflows/claude-code-review.yml@v1
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      model: sonnet
+      review_language: 日本語
+```
+
 ## ワークフロー詳細
 
 ### latex-build.yml
@@ -142,6 +170,27 @@ Gemini AI を使用して PR の自動レビューを行います。
 
 **必要なシークレット:**
 - `GEMINI_API_KEY`
+
+### claude-code-review.yml
+
+Claude Code Action を使用して PR の自動レビューを行います。GitHub Copilot review の premium request quota 超過対策として導入しました。
+
+**入力パラメータ:**
+| パラメータ | 必須 | デフォルト | 説明 |
+|-----------|:----:|-----------|------|
+| `model` | No | `sonnet` | 使用モデル（`sonnet` / `opus` / `haiku`）。卒論・修論など重要リポジトリは `opus` を推奨 |
+| `review_language` | No | `日本語` | レビューコメントの言語 |
+| `timeout_minutes` | No | `15` | ジョブタイムアウト（分） |
+
+**必要なシークレット:**
+- `anthropic_api_key`: Console 発行の `ANTHROPIC_API_KEY`（従量課金）。Claude Max の OAuth トークンは使用不可（他者の PR 横断レビューには規約上 API キーが必要）
+
+**必要な権限:** caller 側のジョブに `id-token: write`（claude-code-action の OIDC 認証で必須）に加え、`contents: read` / `pull-requests: write` / `issues: write`。
+
+**挙動:**
+- draft PR はスキップ（`ready_for_review` で起動）
+- fork PR では secret が渡らないため安全にスキップ
+- ワークフローファイルは default ブランチに存在する必要がある（claude-code-action のセキュリティ検証）
 
 ### create-next-draft.yml
 


### PR DESCRIPTION
## 概要

先にマージした `claude-code-review.yml`（reusable）を README に追記する。あわせて、**main にワークフローが乗った状態で Claude 自動レビューが実際に起動するか**を確認するテスト PR を兼ねる。

## 変更内容

- Reusable Workflows 一覧テーブルに `claude-code-review.yml` の行を追加
- 「使い方 > 使用例」に Claude レビューの caller 例を追加（`@v1` 参照、`id-token: write` 含む）
- 「ワークフロー詳細」に `claude-code-review.yml` 節を追加（入力パラメータ・必要シークレット・必要権限・挙動）

## 確認したいこと

- この PR で **Claude Code Review** が起動し、日本語でレビューコメントが付くこと
- **AI Reviewer (Gemini)** は `GEMINI_API_KEY` 未設定なら従来どおりスキップされること

ドキュメントのみの変更でコードへの影響はなし。
