### PR TITLE
debug: surface Claude permission denials via show_full_output

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,6 +48,11 @@ on:
         type: number
         required: false
         default: 15
+      show_full_output:
+        description: "Claude の全出力をログに表示（デバッグ用）。permission_denials の調査時のみ true"
+        type: boolean
+        required: false
+        default: false
     secrets:
       anthropic_api_key:
         description: "Anthropic API key（caller から渡す）"
@@ -94,6 +99,7 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           claude_args: "--model ${{ inputs.model }}"
+          show_full_output: ${{ inputs.show_full_output }}
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,3 +31,4 @@ jobs:
     with:
       model: sonnet
       review_language: 日本語
+      show_full_output: true   # TEMP(debug): permission_denials 調査のため。完了後 false に戻す


### PR DESCRIPTION
## 目的

PR #32 で Claude Code Review が `success` したのに**レビューを投稿しなかった**問題（`No buffered inline comments` ＋ `permission_denials_count: 19`）の原因を特定する。Claude の SDK 出力は既定で `full output hidden for security` のため、`show_full_output` を一時的に有効化して 19 件の権限拒否ツールを可視化する。

## 変更内容

- reusable `claude-code-review.yml` に **`show_full_output` 入力（boolean, 既定 false）** を追加し、`anthropics/claude-code-action` に渡す
- `.github` の self-caller `claude-review.yml` で **一時的に `show_full_output: true`**（調査後に false へ戻す）

## ⚠️ 検証ゲートに関する注意

claude-code-action は「起動中のワークフローが default ブランチと同一内容」であることを要求するため、**このデバッグ設定はこの PR 自身では効きません**（ワークフロー変更 PR なので Claude はスキップ）。**main にマージ後**、別途トリガーした PR（例: #32 への再 push）で初めて全出力が取得できます。

## 段取り

1. この PR を main にマージ
2. PR #32 に軽微な再 push → Claude が `show_full_output: true` で実行
3. ログで 19 件の拒否ツールを特定 → 必要ツールを許可する恒久対応（別 PR）
4. この `show_full_output: true` を false に戻す

デバッグ用の一時変更です。
