### PR TITLE
chore: disable show_full_output after Claude review diagnosis

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,4 +31,3 @@ jobs:
     with:
       model: sonnet
       review_language: 日本語
-      show_full_output: true   # TEMP(debug): permission_denials 調査のため。完了後 false に戻す


### PR DESCRIPTION
## 概要

Claude レビュー不投稿問題の調査が完了したため、self-caller の一時デバッグフラグ `show_full_output: true` を撤去する。

## 調査結果（PR #34 / run 27090644169）

- **Claude レビューは正常動作**。bait ファイルに対し inline コメント2件を投稿（🚨[HIGH] `rm -rf` のセキュリティ / ℹ️[LOW] スタイル）
- **`permission_denials_count: 19` の中身は全て `Bash` / `Write`** — Claude がコードを実行して再現確認しようとした試みが、レビュー用サンドボックスの既定で拒否されたもの。**未信頼コード実行を防ぐ仕様どおりの安全動作で無害**
- PR #32 で Claude が無言だったのは docs のみで実質的指摘が無かったため（正常）

## 変更内容

- `claude-review.yml`（self-caller）から `show_full_output: true` を削除
- reusable 側の `show_full_output` 入力（既定 false）は便利なデバッグつまみとして残置

恒久的な追加対応は不要と判明しました。
