### PR TITLE
perf: replace code-review plugin with lightweight single-pass review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,13 @@
 # Reusable Claude Code Review Workflow
 #
-# Runs an automated PR review with Claude Code Action. Designed as the shared
-# org-wide review workflow to avoid GitHub Copilot premium request quota limits.
+# Runs a lightweight single-pass PR review with Claude Code Action. Designed as
+# the shared org-wide review workflow to avoid GitHub Copilot premium request
+# quota limits.
+#
+# This intentionally does NOT use the code-review plugin: that plugin fans out
+# into 8+ sub-agents (including Opus) per review, taking ~5 min and ~$0.6. A
+# single focused prompt with a bounded turn count reviews in ~60-90s for ~$0.15
+# (sonnet) and posts inline comments for real issues plus a summary comment.
 #
 # Authentication uses a Console-issued ANTHROPIC_API_KEY (metered billing),
 # NOT a Claude Max OAuth token (subscription tokens are for personal use and
@@ -10,10 +16,11 @@
 # Required secrets:
 #   - anthropic_api_key: Console-issued Anthropic API key (passed from caller)
 #
-# Usage (caller in each target repository):
+# Usage (caller in each target repository). Trigger on opened/ready_for_review
+# (NOT synchronize) to avoid re-reviewing on every push:
 #   on:
 #     pull_request:
-#       types: [opened, synchronize, reopened, ready_for_review]
+#       types: [opened, reopened, ready_for_review]
 #   jobs:
 #     review:
 #       uses: smkwlab/.github/.github/workflows/claude-code-review.yml@v1
@@ -96,13 +103,23 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
-          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
-          plugins: "code-review@claude-code-plugins"
-          claude_args: "--model ${{ inputs.model }}"
           show_full_output: ${{ inputs.show_full_output }}
+          # Single-pass review: bounded turns, only the tools needed to read the
+          # PR and post comments. No Write/arbitrary Bash, so Claude does static
+          # review instead of trying (and failing) to execute the PR's code.
+          claude_args: |
+            --model ${{ inputs.model }}
+            --max-turns 15
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            このプルリクエスト（${{ github.repository }} #${{ github.event.pull_request.number }}）を${{ inputs.review_language }}でレビューしてください。コードは実行せず、差分を静的に確認してください。
 
-            レビューコメントはすべて${{ inputs.review_language }}で記述してください。
-            各指摘には重大度（critical / warning / nit）のラベルを付けてください。
-            スタイルの好みより、バグ・セキュリティ・ロジックの問題を優先してください。
+            重点（この順で優先）:
+            - ロジックの誤り・未処理の例外・境界条件の見落とし
+            - セキュリティ（入力検証、認証・認可、機密情報の漏えい、危険なコマンド実行）
+            - 仕様・意図との不一致や明らかなバグ
+
+            スタイルの好みや軽微なリファクタリング提案は対象外です。重大な問題のみを指摘してください。
+
+            指摘は該当行への inline コメント（mcp__github_inline_comment__create_inline_comment）として投稿し、各指摘の先頭に重大度ラベル [critical] / [warning] / [nit] を付けてください。
+            重大な問題が無い場合は、レビューした旨と確認した観点を1件の要約コメント（gh pr comment）として投稿してください。

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,7 +12,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]   # synchronize 除外: 毎 push の再レビューを避ける
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 背景

`code-review` プラグインは1レビューで **8個以上のサブエージェント（内部で Opus を含む）** を多段起動するため、`--model sonnet` 指定でも **約5分・約 $0.6** かかる。Copilot quota 回避＝低コスト運用という目的に対して過剰で、毎 push の `synchronize` でさらに増幅される。

（公式仕様・ログ実測で確認: プラグインは Haiku ゲートキーパー → メタデータ → Sonnet 要約 → 並列4個（Opus×2 でバグ検出）→ 検証エージェント、という構成）

## 変更内容

reusable を**軽量シングルパス**に置換:

- `plugin_marketplaces` / `plugins` を廃止し、日本語プロンプト直書きの単発レビューに変更
- `--max-turns 15` ＋ 必要最小の `--allowedTools`（inline コメント MCP ツール ＋ 読み取り専用 `gh`）に限定 → コード実行を試みず**静的レビュー**で inline ＋要約コメントを投稿
- self-caller のトリガーから **`synchronize` を除外**（`opened` / `reopened` / `ready_for_review`）

## 期待効果

| | 旧（プラグイン） | 新（単発） |
|---|---|---|
| 所要時間 | 約5分 | **約60〜90秒** |
| コスト | 約 $0.6 | **約 $0.15**（sonnet） |
| 頻度 | 毎 push | PR ごと（synchronize 除外） |

精査の深さは下がるが、バグ・セキュリティの実質的指摘は単発でも inline で拾える。

## マージ後のテスト（必須）

プラグイン廃止後の投稿経路（inline コメント MCP ツール）は実証が必要なため、**マージ後にテスト PR で「60〜90秒・要約＋inline 投稿」を確認**します。

## 注意

- 配布スクリプト（PR #36）の caller テンプレートと README 例も `synchronize` 除外へ追従が必要。本 PR とは別に更新します。
