### PR TITLE
feat: add interactive @claude mention workflow

### DIFF
--- a/.github/workflows/claude-mention-self.yml
+++ b/.github/workflows/claude-mention-self.yml
@@ -1,0 +1,44 @@
+# Claude Mention — caller for this (.github) repository itself.
+#
+# Interactive @claude handler. References the reusable by local path so this
+# repo's own issues/PRs can use @claude without waiting for a tag.
+#
+# Comment-triggered workflows run from the DEFAULT branch, so this must be on
+# the default branch to take effect.
+
+name: Claude Mention
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened]
+
+jobs:
+  claude:
+    # Run only when @claude is mentioned AND the author has repository access.
+    # The author_association guard prevents random/external users from
+    # triggering a contents:write session. Fork PRs receive no secret anyway.
+    if: >
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    uses: ./.github/workflows/claude-mention.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      model: sonnet
+      language: 日本語

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,101 @@
+# Reusable Claude Mention Workflow
+#
+# Interactive @claude handler: a user mentions @claude in an issue comment, PR
+# comment, or new issue to ask a question or request a fix. Claude replies and
+# (for fix requests) can commit changes to the PR branch.
+#
+# This is separate from the review workflow (claude-code-review.yml): review is
+# automatic on PR open, this is on-demand via the @claude trigger phrase.
+#
+# Authentication uses a Console-issued ANTHROPIC_API_KEY (metered billing).
+#
+# Required secrets:
+#   - anthropic_api_key: Console-issued Anthropic API key (passed from caller)
+#
+# Usage (caller in each target repository). Filter the @claude mention AND the
+# author's permission in the CALLER's job `if:` (see claude-mention-self.yml):
+#   on:
+#     issue_comment:
+#       types: [created]
+#     pull_request_review_comment:
+#       types: [created]
+#     issues:
+#       types: [opened]
+#   jobs:
+#     claude:
+#       if: <@claude present AND author_association in OWNER/MEMBER/COLLABORATOR>
+#       uses: smkwlab/.github/.github/workflows/claude-mention.yml@v1
+#       permissions:
+#         contents: write
+#         pull-requests: write
+#         issues: write
+#         id-token: write
+#       secrets:
+#         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+#       with:
+#         model: sonnet
+
+name: Claude Mention (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "使用モデル（sonnet / opus / haiku）"
+        type: string
+        required: false
+        default: "sonnet"
+      language:
+        description: "応答の言語"
+        type: string
+        required: false
+        default: "日本語"
+      timeout_minutes:
+        description: "ジョブのタイムアウト（分）。対話セッションの暴走/課金を防ぐ"
+        type: number
+        required: false
+        default: 20
+    secrets:
+      anthropic_api_key:
+        description: "Anthropic API key（caller から渡す）"
+        required: true
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    permissions:
+      contents: write        # @claude の修正依頼で PR ブランチへコミットするため
+      pull-requests: write
+      issues: write
+      id-token: write        # required by claude-code-action for OIDC
+    steps:
+      - name: Check ANTHROPIC_API_KEY
+        id: check-key
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::notice::ANTHROPIC_API_KEY is not configured (or unavailable on fork PRs). Skipping @claude."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude
+        if: steps.check-key.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          # Tag mode: no `prompt` — the @claude comment body becomes the instruction.
+          trigger_phrase: "@claude"
+          claude_args: |
+            --model ${{ inputs.model }}
+            --max-turns 30
+            --append-system-prompt "応答はすべて${{ inputs.language }}で記述してください。コードを修正する場合はリポジトリの CLAUDE.md と既存コードの慣習に従ってください。"


### PR DESCRIPTION
## 概要

`@claude` メンションで対話的に質問・修正依頼ができるワークフローを追加する。自動レビュー（`claude-code-review.yml`）とは別系統で、**オンデマンド**で起動する。

## 追加ファイル

- `claude-mention.yml`: reusable（`workflow_call`）。タグモード（`prompt` 省略・`trigger_phrase: "@claude"`）で、コメント本文を指示として解釈。`contents: write` で**修正依頼時に PR ブランチへコミット可能**。`--max-turns 30`、`--append-system-prompt` で日本語応答。secret 不在時はグレースフルスキップ
- `claude-mention-self.yml`: `.github` 自身用 caller（ローカルパス参照）。`issue_comment` / `pull_request_review_comment` / `issues` で起動

## セキュリティ設計（重要）

`contents: write` を持つため、**誰でもトリガーできると任意コードをコミットさせられる**リスクがあります。caller の `if` で二重にガード:

1. 本文に `@claude` を含む
2. かつ **`author_association` が `OWNER` / `MEMBER` / `COLLABORATOR`**（リポジトリ権限保有者のみ）

→ 外部/未権限ユーザーのコメントでは起動しません。fork PR では secret も渡りません。

## テスト（マージ後）

コメント起動ワークフローは**デフォルトブランチから実行**されるため、マージ後に `.github` の Issue/PR で `@claude <質問>` を投稿して応答を確認します。

## 配布

レビュー同様、後で `@v1` 参照の caller を各テンプレートへ配布可能（本 PR は本体＋self-caller のみ）。
