### PR TITLE
fix: serialize @claude mention sessions per conversation

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -60,6 +60,14 @@ on:
         description: "Anthropic API key（caller から渡す）"
         required: true
 
+# Serialize @claude sessions per conversation. cancel-in-progress: false (unlike
+# the review workflow) so an in-flight fix is never killed mid-commit and no two
+# sessions push to the same PR branch concurrently; overlapping requests queue.
+# Evaluated against the caller's inherited event, so every caller benefits.
+concurrency:
+  group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 背景

`@claude` mention ワークフローには concurrency 制御が無く、同一 Issue/PR への複数 `@claude` が**並列実行**されていた。Q&A では二重課金・応答ノイズ、**修正依頼では同じ PR ブランチへの push 競合**（片方失敗）のリスクがある。

## 変更内容

reusable `claude-mention.yml` のトップレベルに concurrency を追加:

```yaml
concurrency:
  group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
  cancel-in-progress: false
```

- **会話（Issue/PR）単位で直列化**
- **`cancel-in-progress: false`**: レビュー用（`true`）とは逆方針。修正コミット中のセッションを途中で殺さず、別人の依頼も取りこぼさない。重なった依頼は並列ではなく待機
- **reusable に1か所**置くことで、`github.event` を継承し**全 caller（self・配布先）が自動で恩恵**（DRY）

## 検証

- YAML OK / actionlint clean
- マージ後、`@v1` 更新で全 caller に反映

レビュー用 `claude-code-review.yml` の concurrency（`cancel-in-progress: true`）は変更なし（最新 diff だけ見れば良いので方針が異なるのは意図的）。
