### PR TITLE
Bump ai-academic-paper-reviewer to v1.6 (inline posting hardening)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: AI Review
         if: steps.check.outputs.skip != 'true'
-        uses: smkwlab/ai-academic-paper-reviewer@v1.5
+        uses: smkwlab/ai-academic-paper-reviewer@v1.6
         with:
           GEMINI_API_KEY: ${{ secrets.gemini_api_key }}
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}


### PR DESCRIPTION
## 概要

ワンショット reusable `ai-review.yml` が参照する reviewer action を `@v1.5` → `@v1.6` に更新します。

## 取り込む変更（smkwlab/ai-academic-paper-reviewer#28）

- インラインコメントを diff 内の有効行へフィルタ、範囲外は review body に畳んで保全
- インライン投稿が失敗しても body のみの要約に自動フォールバック
- CODE / ACADEMIC 両モードのインライン経路（`single_comment=false`）に適用

これにより、コメントが diff 外行を指して `createReview` 全体が 422 で失敗し**投稿ゼロ**になる問題が解消されます。実機（toshi-iot74）＋統合テストで検証済み。

関連: smkwlab/ai-academic-paper-reviewer#26 / #28（リリース v1.6）