### PR TITLE
Re-review on push: add synchronize to review triggers

### DIFF
--- a/.github/workflows/ai-review-self.yml
+++ b/.github/workflows/ai-review-self.yml
@@ -7,7 +7,7 @@ name: AI Review (self)
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]   # no synchronize: avoid re-reviewing on every push (cost). Use @claude for an on-demand re-review.
+    types: [opened, reopened, ready_for_review, synchronize]   # synchronize: re-review on every push (matches the old ai-reviewer). Revisit if cost becomes a concern. concurrency below cancels superseded runs.
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -106,11 +106,12 @@ jobs:
 name: AI Code Review
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    # synchronize で push のたびに再レビュー。コストが問題なら synchronize を外す。
+    types: [opened, reopened, ready_for_review, synchronize]
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: true   # 連続 push 時は古い実行をキャンセル
 
 jobs:
   review:

--- a/scripts/callers/ai-code-review.yml
+++ b/scripts/callers/ai-code-review.yml
@@ -6,7 +6,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]   # no synchronize: avoid re-reviewing every push
+    types: [opened, reopened, ready_for_review, synchronize]   # synchronize: re-review on each push. concurrency below cancels superseded runs. Drop synchronize if cost is a concern.
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}

--- a/scripts/callers/ai-paper-review.yml
+++ b/scripts/callers/ai-paper-review.yml
@@ -6,7 +6,7 @@ name: AI Paper Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]   # no synchronize: avoid re-reviewing every push
+    types: [opened, reopened, ready_for_review, synchronize]   # synchronize: re-review on each push. concurrency below cancels superseded runs. Drop synchronize if cost is a concern.
 
 concurrency:
   group: ai-paper-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 概要

PR への push のたびに自動再レビューが走るよう、AI レビュー caller のトリガに `synchronize` を追加します（旧 `toshi0806/ai-reviewer` が `synchronize` で実現していた挙動の復元）。

## 背景

新 `ai-review` 系は毎 push のコストを避けて `synchronize` を外していましたが、旧 ai-reviewer と同じ「push で再レビュー」の利便を一旦採用して運用してみます。**コストが問題になれば `synchronize` を外して見直す**方針。

## 変更（源流のみ）

- `.github/workflows/ai-review-self.yml`（self-caller）
- `scripts/callers/ai-code-review.yml` / `ai-paper-review.yml`（配布テンプレート）
- README の使用例を整合

`concurrency: cancel-in-progress: true` が既にあるため、連続 push 時は古い実行がキャンセルされ多重実行は抑制されます。

## 注意（配布済みへの反映）

本 PR は**源流（.github の self-caller ＋ 配布テンプレート）**のみ。既に配布済みの caller（ドキュメントテンプレ 6・コード repo 7・toshi-iot74）は `synchronize` を持たないため、反映には別途 retrofit が必要です（範囲は別途相談）。

関連: 旧 ai-reviewer の `types: [opened, synchronize, reopened]`