### PR TITLE
ci: bump ai-academic-paper-reviewer to v1.7

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: AI Review
         if: steps.check.outputs.skip != 'true'
-        uses: smkwlab/ai-academic-paper-reviewer@v1.6
+        uses: smkwlab/ai-academic-paper-reviewer@v1.7
         with:
           GEMINI_API_KEY: ${{ secrets.gemini_api_key }}
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}


### PR DESCRIPTION
## 概要

`ai-review.yml` が参照する action を `@v1.6` → `@v1.7` に更新する。

## 背景

新しい Anthropic モデル（Claude Opus 4.7 / 4.8、Fable 5）では \`temperature\` が削除されており、送ると 400（\`temperature is deprecated for this model\`）になる。\`ai-academic-paper-reviewer@v1.6\` は \`generateObject\` に常に \`temperature\` を渡していたため、\`model_code: claude-opus-4-8\` を指定した caller（tenbin_ex 等）で AI レビューが失敗していた。

action 側で修正済み（ai-academic-paper-reviewer#30 → v1.7）。本 PR でその v1.7 を取り込む。

## バージョニング規約との整合

- action 参照はピン留めしたマイナータグを使う規約に従い、明示的チェックポイントとして \`@v1.6\` → \`@v1.7\` に bump
- 入出力・トリガに変更はなく、全ワークフローに対して非破壊 → マージ後に floating \`v1\` を進めてよい（前回 #53 と同じ運用）

## マージ後の作業（別途）

1. 不変リリース \`v1.17.0\` を発行（#54 / #55 と本 bump をまとめる）
2. floating \`v1\` を新 main HEAD へ付け替え