### PR TITLE
ci: bump ai-academic-paper-reviewer to v1.8 (temperature fix)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: AI Review
         if: steps.check.outputs.skip != 'true'
-        uses: smkwlab/ai-academic-paper-reviewer@v1.7
+        uses: smkwlab/ai-academic-paper-reviewer@v1.8
         with:
           GEMINI_API_KEY: ${{ secrets.gemini_api_key }}
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}


### PR DESCRIPTION
## Summary

AI レビュー再利用ワークフロー `ai-review.yml` が参照する reviewer action を `@v1.7` → `@v1.8` に更新します。

## 背景

`temperature` を deprecate したモデル（Opus 4.7+ / Fable 5+）に `temperature` を送らない修正（reviewer action #30, commit d3cbd5d）は v1.7 のコード上は正しく入っています。しかし v1.7 タグを後から張り替えたため、GitHub Actions のアクションキャッシュが旧 tarball（temperature 無条件送信版）を配信し続け、実行時は依然 400 (`temperature is deprecated for this model`) で失敗していました。

tdig#55（review model を claude-opus-4-8 に変更）で、修正後・v1.7=d3cbd5d でも 3 回のまっさらな run が全て temperature 送信で失敗することを確認済みです。

## 対応

タグ張り替えは Actions で不安定なため、同一修正コミット d3cbd5d を指す新規タグ v1.8 を発行し、本ワークフローからそれを参照するよう変更しました。

## Changes

- `uses: smkwlab/ai-academic-paper-reviewer@v1.7` → `@v1.8`（line 99）

## マージ後に必要な作業

- 利用側は `ai-review.yml@v1` を参照しているため、マージ後に v1 タグを新しい main コミットへ張り直す必要があります。