### PR TITLE
ci: bump ai-academic-paper-reviewer to v1.9 (AI SDK v6 temperature fix)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: AI Review
         if: steps.check.outputs.skip != 'true'
-        uses: smkwlab/ai-academic-paper-reviewer@v1.8
+        uses: smkwlab/ai-academic-paper-reviewer@v1.9
         with:
           GEMINI_API_KEY: ${{ secrets.gemini_api_key }}
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}


### PR DESCRIPTION
## Summary

AI レビュー再利用ワークフロー `ai-review.yml` が参照する reviewer action を `@v1.8` → `@v1.9` に更新します。

## 背景

v1.7/v1.8 の temperature omit 修正は、**AI SDK v4 が temperature デフォルト 0 を強制注入**するため無効でした（Opus 4.7+/Fable 5+ で 400 `temperature is deprecated`）。

reviewer action #31 で **AI SDK を v6 に上げ**（v5 でデフォルト 0 撤廃、v6 も同様）、既存の `supportsTemperature` ガードが実際に機能するようになりました。これを v1.9 として発行済みです。

## Changes

- `uses: smkwlab/ai-academic-paper-reviewer@v1.8` → `@v1.9`（line 99）

## マージ後

- 利用側は `ai-review.yml@v1` を参照しているため、マージ後に `v1` タグを新 main コミットへ張り直します。