### PR TITLE
feat: add one-shot QA path for @claude mention (claude-qa.yml)

### DIFF
--- a/.github/workflows/claude-mention-self.yml
+++ b/.github/workflows/claude-mention-self.yml
@@ -3,6 +3,13 @@
 # Interactive @claude handler. References the reusable by local path so this
 # repo's own issues/PRs can use @claude without waiting for a tag.
 #
+# EVALUATION (#50): every @claude mention here triggers BOTH the agent
+# (claude-mention.yml, claude-code-action) and the one-shot QA path
+# (claude-qa.yml), so their answer quality and latency can be compared on the
+# same questions in situ. Once the comparison concludes, the losing job gets
+# removed (and, if one-shot wins, the distributed caller is migrated and
+# claude-code-action dropped).
+#
 # Comment-triggered workflows run from the DEFAULT branch, so this must be on
 # the default branch to take effect.
 
@@ -42,4 +49,29 @@ jobs:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
       model: sonnet
+      language: 日本語
+
+  # One-shot QA path under evaluation (#50). Same guard as the agent job above;
+  # both answer the same mention so they can be compared. No id-token: the
+  # one-shot path does not use OIDC.
+  claude-qa:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    uses: ./.github/workflows/claude-qa.yml
+    permissions:
+      contents: read         # least privilege; the QA path never checks out the repo
+      pull-requests: write
+      issues: write
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      model: claude-sonnet-4-6
       language: 日本語

--- a/.github/workflows/claude-mention-self.yml
+++ b/.github/workflows/claude-mention-self.yml
@@ -54,6 +54,8 @@ jobs:
   # One-shot QA path under evaluation (#50). Same guard as the agent job above;
   # both answer the same mention so they can be compared. No id-token: the
   # one-shot path does not use OIDC.
+  # TODO(#50): remove one of the two jobs when the A/B evaluation concludes —
+  # do not leave both running (double cost per mention).
   claude-qa:
     if: >
       (github.event_name == 'issue_comment' &&

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -13,8 +13,8 @@
 # This is separate from the review workflow (ai-review.yml): review is automatic
 # on PR open, this is on-demand via the @claude trigger phrase. Both are now
 # advice-only; the agent (claude-code-action) is kept here only so @claude can
-# read/search the repo to answer well — replacing it with a one-shot QA path is
-# tracked separately.
+# read/search the repo to answer well — claude-qa.yml is a one-shot replacement
+# candidate under evaluation (#50, run side by side in claude-mention-self.yml).
 #
 # Authentication uses a Console-issued ANTHROPIC_API_KEY (metered billing).
 #

--- a/.github/workflows/claude-qa.yml
+++ b/.github/workflows/claude-qa.yml
@@ -1,0 +1,293 @@
+# Reusable Claude QA Workflow (one-shot)
+#
+# One-shot @claude handler: answers a question asked via @claude in an issue
+# comment, PR comment, PR review comment, or new issue with a SINGLE Messages
+# API call (no agent loop). Self-contained plumbing:
+#   - event parsing (issue_comment / pull_request_review_comment / issues)
+#   - context collection (PR -> diff, issue -> body, review comment -> file/
+#     line + thread, conversation history)
+#   - one Anthropic Messages API call
+#   - reply posting (thread reply for review comments, issue comment otherwise)
+#     plus an eyes reaction to acknowledge receipt
+#
+# ADVICE-ONLY by construction: there is no checkout and no agent, so it cannot
+# edit or commit anything. Unlike claude-mention.yml (claude-code-action) it
+# cannot search the repo either — it answers from the context assembled above
+# and is expected to say what is missing when that is not enough.
+#
+# This is the one-shot QA path explored in issue #50 as a replacement for the
+# claude-code-action based claude-mention.yml. No OIDC/id-token, no max-turns,
+# no runaway sessions; same one-shot architecture as ai-review.yml. While under
+# evaluation, claude-mention-self.yml runs both side by side for comparison.
+#
+# Required secrets:
+#   - anthropic_api_key: Console-issued Anthropic API key (passed from caller)
+#
+# Usage (caller in each target repository). Filter the @claude mention AND the
+# author's permission in the CALLER's job `if:` (same guard as claude-mention):
+#   on:
+#     issue_comment:
+#       types: [created]
+#     pull_request_review_comment:
+#       types: [created]
+#     issues:
+#       types: [opened]
+#   jobs:
+#     claude-qa:
+#       if: <@claude present AND author_association in OWNER/MEMBER/COLLABORATOR>
+#       uses: smkwlab/.github/.github/workflows/claude-qa.yml@v1
+#       permissions:
+#         contents: read         # least privilege; no checkout, no commits
+#         pull-requests: write   # to post the reply / reaction on PRs
+#         issues: write          # to post the reply / reaction on issues
+#       secrets:
+#         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+#       with:
+#         model: claude-sonnet-4-6
+
+name: Claude QA (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "Anthropic model code for the Messages API (e.g. claude-sonnet-4-6)"
+        type: string
+        required: false
+        default: "claude-sonnet-4-6"
+      language:
+        description: "応答の言語"
+        type: string
+        required: false
+        default: "日本語"
+      timeout_minutes:
+        description: "ジョブのタイムアウト（分）"
+        type: number
+        required: false
+        default: 10
+    secrets:
+      anthropic_api_key:
+        description: "Anthropic API key（caller から渡す）"
+        required: true
+
+# Serialize per conversation, queue follow-ups instead of cancelling (each
+# mention is a distinct question deserving a reply) — same policy as
+# claude-mention.yml but a separate group, so the two can run side by side
+# during the #50 evaluation. Evaluated against the caller's inherited event.
+concurrency:
+  group: claude-qa-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    permissions:
+      contents: read         # least privilege; this job never checks out the repo
+      pull-requests: write   # reply / reaction on PRs
+      issues: write          # reply / reaction on issues
+    steps:
+      # Gracefully skip when the key is absent (e.g. fork PRs receive no secrets).
+      - name: Check ANTHROPIC_API_KEY
+        id: check-key
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::notice::ANTHROPIC_API_KEY is not configured (or unavailable on fork PRs). Skipping @claude QA."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Answer with one Messages API call
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+          QA_MODEL: ${{ inputs.model }}
+          QA_LANGUAGE: ${{ inputs.language }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const eventName = context.eventName;
+            const payload = context.payload;
+            const model = process.env.QA_MODEL;
+            const language = process.env.QA_LANGUAGE;
+
+            // Per-section clip keeps one huge section (usually the diff) from
+            // crowding out the question and thread; TOTAL_BUDGET caps the call.
+            const clip = (s, n, label) => {
+              s = s || '';
+              return s.length <= n ? s : s.slice(0, n) + `\n…[${label} が長いため ${n} 文字で切り詰め]`;
+            };
+            const TOTAL_BUDGET = 120000; // chars (~30k tokens), well under the context window
+
+            // --- 1. Parse the event: question, conversation number, reply target ---
+            let question, issueNumber, isPR, reviewComment = null;
+            if (eventName === 'issues') {
+              question = payload.issue.body;
+              issueNumber = payload.issue.number;
+              isPR = !!payload.issue.pull_request;
+            } else if (eventName === 'issue_comment') {
+              question = payload.comment.body;
+              issueNumber = payload.issue.number;
+              isPR = !!payload.issue.pull_request;
+            } else if (eventName === 'pull_request_review_comment') {
+              question = payload.comment.body;
+              issueNumber = payload.pull_request.number;
+              isPR = true;
+              reviewComment = payload.comment;
+            } else {
+              core.setFailed(`Unsupported event: ${eventName} (use issue_comment / pull_request_review_comment / issues)`);
+              return;
+            }
+
+            // --- 2. Eyes reaction to acknowledge receipt (best effort) ---
+            try {
+              if (eventName === 'issues') {
+                await github.rest.reactions.createForIssue({ owner, repo, issue_number: issueNumber, content: 'eyes' });
+              } else if (eventName === 'issue_comment') {
+                await github.rest.reactions.createForIssueComment({ owner, repo, comment_id: payload.comment.id, content: 'eyes' });
+              } else {
+                await github.rest.reactions.createForPullRequestReviewComment({ owner, repo, comment_id: reviewComment.id, content: 'eyes' });
+              }
+            } catch (e) {
+              core.warning(`eyes リアクションの付与に失敗: ${e.message}`);
+            }
+
+            // --- 3. Collect context ---
+            const parts = [];
+
+            // Issue / PR title and body
+            if (eventName === 'pull_request_review_comment') {
+              const pr = payload.pull_request;
+              parts.push(`# Pull Request #${issueNumber}: ${pr.title}\n\n${clip(pr.body, 10000, 'PR 本文')}`);
+            } else {
+              const issue = payload.issue;
+              parts.push(`# ${isPR ? 'Pull Request' : 'Issue'} #${issueNumber}: ${issue.title}\n\n${clip(issue.body, 10000, '本文')}`);
+            }
+
+            // PR diff (fallback: file list when the diff is too large to fetch)
+            if (isPR) {
+              try {
+                const { data: diff } = await github.rest.pulls.get({
+                  owner, repo, pull_number: issueNumber, mediaType: { format: 'diff' },
+                });
+                parts.push(`## PR の diff\n\n\`\`\`diff\n${clip(String(diff), 60000, 'diff')}\n\`\`\``);
+              } catch (e) {
+                core.warning(`diff の取得に失敗（大きすぎる可能性）: ${e.message}`);
+                try {
+                  const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: issueNumber, per_page: 100 });
+                  const list = files.map(f => `- ${f.filename} (${f.status}, +${f.additions}/-${f.deletions})`).join('\n');
+                  parts.push(`## PR の変更ファイル一覧（diff 本体は大きすぎるため取得できず）\n\n${clip(list, 10000, 'ファイル一覧')}`);
+                } catch (e2) {
+                  core.warning(`変更ファイル一覧の取得にも失敗: ${e2.message}`);
+                }
+              }
+            }
+
+            // Review comment: file/line target + its thread
+            if (reviewComment) {
+              parts.push([
+                '## このレビューコメントの対象',
+                `- ファイル: ${reviewComment.path}`,
+                `- 行: ${reviewComment.line ?? reviewComment.original_line ?? '不明'}`,
+                '',
+                '対象の diff hunk:',
+                '```diff',
+                clip(reviewComment.diff_hunk, 5000, 'diff hunk'),
+                '```',
+              ].join('\n'));
+              try {
+                const all = await github.paginate(github.rest.pulls.listReviewComments, { owner, repo, pull_number: issueNumber, per_page: 100 });
+                const rootId = reviewComment.in_reply_to_id || reviewComment.id;
+                const thread = all.filter(c => (c.id === rootId || c.in_reply_to_id === rootId) && c.id !== reviewComment.id);
+                if (thread.length) {
+                  parts.push('## このスレッドのこれまでのコメント\n\n' + thread
+                    .map(c => `### ${c.user.login} (${c.created_at})\n${clip(c.body, 3000, 'コメント')}`)
+                    .join('\n\n'));
+                }
+              } catch (e) {
+                core.warning(`レビュースレッドの取得に失敗: ${e.message}`);
+              }
+            }
+
+            // Conversation history (issue / PR comments before the mention)
+            if (eventName === 'issue_comment') {
+              try {
+                const all = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: issueNumber, per_page: 100 });
+                const prior = all.filter(c => c.id !== payload.comment.id).slice(-20);
+                if (prior.length) {
+                  parts.push('## これまでの会話（直近のコメント）\n\n' + prior
+                    .map(c => `### ${c.user.login} (${c.created_at})\n${clip(c.body, 3000, 'コメント')}`)
+                    .join('\n\n'));
+                }
+              } catch (e) {
+                core.warning(`コメント履歴の取得に失敗: ${e.message}`);
+              }
+            }
+
+            const contextText = clip(parts.join('\n\n'), TOTAL_BUDGET, '文脈全体');
+
+            // --- 4. One Messages API call ---
+            const system = [
+              `あなたは GitHub 上の Issue / Pull Request で質問に答えるレビュー補助アシスタントです。応答はすべて${language}で記述してください。`,
+              'あなたは助言・指摘のみを行います。ファイルの編集・コミット・プッシュは行えません。必要な修正は具体的な提案として文章やコード片で示し、適用は質問者に委ねてください。',
+              'リポジトリを検索することはできません。以下に与えられた文脈（Issue/PR 本文・diff・コメント）だけを根拠に回答し、文脈に無い情報が必要な場合は推測で断定せず、何が分かれば答えられるかを明示してください。',
+              '回答はそのまま GitHub のコメントとして投稿されます。GitHub Flavored Markdown で、要点から簡潔に書いてください。',
+            ].join('\n');
+            const userMsg = [
+              `次の ${isPR ? 'Pull Request' : 'Issue'} で @claude にメンションされました。文脈を踏まえて質問・依頼に回答してください。`,
+              '',
+              '## 質問・依頼（メンションされた本文）',
+              '',
+              clip(question, 10000, '質問'),
+              '',
+              '## 文脈',
+              '',
+              contextText,
+            ].join('\n');
+
+            const resp = await fetch('https://api.anthropic.com/v1/messages', {
+              method: 'POST',
+              headers: {
+                'x-api-key': process.env.ANTHROPIC_API_KEY,
+                'anthropic-version': '2023-06-01',
+                'content-type': 'application/json',
+              },
+              body: JSON.stringify({
+                model,
+                max_tokens: 8192,
+                system,
+                messages: [{ role: 'user', content: userMsg }],
+              }),
+            });
+            if (!resp.ok) {
+              core.setFailed(`Anthropic API error ${resp.status}: ${await resp.text()}`);
+              return;
+            }
+            const data = await resp.json();
+            let answer = (data.content || []).filter(b => b.type === 'text').map(b => b.text).join('\n').trim();
+            if (!answer) {
+              core.setFailed('Anthropic API returned an empty answer.');
+              return;
+            }
+            if (data.stop_reason === 'max_tokens') {
+              answer += '\n\n…（回答が出力上限に達したため途中までです）';
+            }
+            core.info(`usage: ${JSON.stringify(data.usage)}`);
+
+            // --- 5. Post the reply ---
+            const body = `${answer}\n\n---\n*🤖 ワンショット QA（claude-qa.yml / ${model}）による回答*`;
+            if (reviewComment) {
+              // Reply in the review thread. The replies endpoint expects the
+              // TOP-LEVEL comment id, so resolve the thread root.
+              await github.rest.pulls.createReplyForReviewComment({
+                owner, repo, pull_number: issueNumber,
+                comment_id: reviewComment.in_reply_to_id || reviewComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+            }

--- a/.github/workflows/claude-qa.yml
+++ b/.github/workflows/claude-qa.yml
@@ -74,6 +74,13 @@ on:
 # mention is a distinct question deserving a reply) — same policy as
 # claude-mention.yml but a separate group, so the two can run side by side
 # during the #50 evaluation. Evaluated against the caller's inherited event.
+#
+# The group expression is the standard fallback idiom (same as
+# claude-mention.yml): missing event properties evaluate to empty in Actions
+# expressions, so issue_comment/issues resolve issue.number and
+# pull_request_review_comment falls through to pull_request.number. For PR
+# conversations issue.number IS the PR number, so every event on one PR shares
+# a group. Do NOT add a run_id fallback — it would disable the serialization.
 concurrency:
   group: claude-qa-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
@@ -202,6 +209,7 @@ jobs:
               try {
                 const all = await github.paginate(github.rest.pulls.listReviewComments, { owner, repo, pull_number: issueNumber, per_page: 100 });
                 const rootId = reviewComment.in_reply_to_id || reviewComment.id;
+                // Latest 20 only — recent thread context matters most.
                 const thread = all.filter(c => (c.id === rootId || c.in_reply_to_id === rootId) && c.id !== reviewComment.id).slice(-20);
                 if (thread.length) {
                   parts.push('## このスレッドのこれまでのコメント\n\n' + thread
@@ -216,6 +224,7 @@ jobs:
             // Conversation history (issue / PR comments before the mention).
             // Collected for review-comment mentions too: the question often
             // refers to the wider PR discussion, not just its own thread.
+            // issues (opened) is skipped: a just-opened issue has no comments.
             if (eventName === 'issue_comment' || eventName === 'pull_request_review_comment') {
               try {
                 const all = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: issueNumber, per_page: 100 });

--- a/.github/workflows/claude-qa.yml
+++ b/.github/workflows/claude-qa.yml
@@ -202,7 +202,7 @@ jobs:
               try {
                 const all = await github.paginate(github.rest.pulls.listReviewComments, { owner, repo, pull_number: issueNumber, per_page: 100 });
                 const rootId = reviewComment.in_reply_to_id || reviewComment.id;
-                const thread = all.filter(c => (c.id === rootId || c.in_reply_to_id === rootId) && c.id !== reviewComment.id);
+                const thread = all.filter(c => (c.id === rootId || c.in_reply_to_id === rootId) && c.id !== reviewComment.id).slice(-20);
                 if (thread.length) {
                   parts.push('## このスレッドのこれまでのコメント\n\n' + thread
                     .map(c => `### ${c.user.login} (${c.created_at})\n${clip(c.body, 3000, 'コメント')}`)
@@ -233,9 +233,12 @@ jobs:
               }
             }
 
-            // Tail-trim drops the lowest-priority sections first (parts are
-            // ordered body -> diff -> review thread -> conversation history);
-            // the question itself lives outside contextText and is never cut.
+            // The trim cuts the END of the joined text. The section order
+            // (body -> diff -> review thread -> conversation history) plus the
+            // per-section caps above guarantee the cut lands in the trailing,
+            // lower-priority sections (thread / history), never inside the
+            // diff (body+diff ≈ 70k < TOTAL_BUDGET); the question itself lives
+            // outside contextText and is never cut.
             const joined = parts.join('\n\n');
             const contextText = clip(joined, TOTAL_BUDGET, '文脈全体');
             if (contextText.length < joined.length) {
@@ -278,7 +281,9 @@ jobs:
               }),
             });
             if (!resp.ok) {
-              core.setFailed(`Anthropic API error ${resp.status}: ${await resp.text()}`);
+              // Truncate: keep logs small and avoid echoing unexpected content.
+              const errText = await resp.text();
+              core.setFailed(`Anthropic API error ${resp.status}: ${errText.slice(0, 500)}`);
               return;
             }
             const data = await resp.json();

--- a/.github/workflows/claude-qa.yml
+++ b/.github/workflows/claude-qa.yml
@@ -213,11 +213,16 @@ jobs:
               }
             }
 
-            // Conversation history (issue / PR comments before the mention)
-            if (eventName === 'issue_comment') {
+            // Conversation history (issue / PR comments before the mention).
+            // Collected for review-comment mentions too: the question often
+            // refers to the wider PR discussion, not just its own thread.
+            if (eventName === 'issue_comment' || eventName === 'pull_request_review_comment') {
               try {
                 const all = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: issueNumber, per_page: 100 });
-                const prior = all.filter(c => c.id !== payload.comment.id).slice(-20);
+                // Drop the triggering comment (already quoted as the question);
+                // review-comment ids live in a different id space, so only
+                // filter on issue_comment events.
+                const prior = all.filter(c => eventName !== 'issue_comment' || c.id !== payload.comment.id).slice(-20);
                 if (prior.length) {
                   parts.push('## これまでの会話（直近のコメント）\n\n' + prior
                     .map(c => `### ${c.user.login} (${c.created_at})\n${clip(c.body, 3000, 'コメント')}`)
@@ -228,7 +233,14 @@ jobs:
               }
             }
 
-            const contextText = clip(parts.join('\n\n'), TOTAL_BUDGET, '文脈全体');
+            // Tail-trim drops the lowest-priority sections first (parts are
+            // ordered body -> diff -> review thread -> conversation history);
+            // the question itself lives outside contextText and is never cut.
+            const joined = parts.join('\n\n');
+            const contextText = clip(joined, TOTAL_BUDGET, '文脈全体');
+            if (contextText.length < joined.length) {
+              core.warning(`文脈全体が ${TOTAL_BUDGET} 文字を超えたため末尾を切り詰めました（元: ${joined.length} 文字）`);
+            }
 
             // --- 4. One Messages API call ---
             const system = [
@@ -249,6 +261,8 @@ jobs:
               contextText,
             ].join('\n');
 
+            // Global fetch is available on github-script@v7's Node 20 runtime
+            // (stable since Node 18); no extra HTTP dependency needed.
             const resp = await fetch('https://api.anthropic.com/v1/messages', {
               method: 'POST',
               headers: {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ smkwlab organization の共通設定および Reusable Workflows を管理する
 | `auto-final-merge.yml` | final-* タグ push 時に承認済み PR を自動マージ | 卒論テンプレート |
 | `ai-review.yml` | ワンショット LLM（Claude/Gemini）による PR 自動レビュー（CODE / ACADEMIC） | 全テンプレート |
 | `claude-mention.yml` | `@claude` メンションによる対話（質問・助言、read-only。claude-code-action） | 全テンプレート |
+| `claude-qa.yml` | `@claude` メンションへのワンショット QA 回答（Messages API 1回、エージェントなし）。`claude-mention.yml` の置き換え候補として評価中（#50） | 評価中（この repo のみ） |
 | `ai-reviewer.yml` | Gemini AI による PR 自動レビュー（旧基盤・`ai-review.yml` に統合予定） | 既存リポジトリ |
 | `notify-ml-on-pr.yml` | PR 作成時にメーリングリストへ通知 | 卒論・ISE レポート |
 
@@ -299,12 +300,35 @@ Gemini AI を使用して PR の自動レビューを行います。
 
 `@claude` メンションによる対話を行います。Issue / PR コメントで `@claude` に話しかけると、リポジトリを読んで質問に回答し、具体的な修正提案を返します。
 
-**助言のみ（read-only）:** ファイルの編集・コミットは行いません（`contents: read`）。修正は提案を見て本人が適用します。卒論・修論など学習目的のリポジトリで「学生が自分で書く」を尊重するための設計です（#49）。応答に repo の read/search が要るため、レビュー（`ai-review.yml`）と違いエージェント（claude-code-action）を維持しています（ワンショット QA 化は別途検討）。
+**助言のみ（read-only）:** ファイルの編集・コミットは行いません（`contents: read`）。修正は提案を見て本人が適用します。卒論・修論など学習目的のリポジトリで「学生が自分で書く」を尊重するための設計です（#49）。応答に repo の read/search が要るため、レビュー（`ai-review.yml`）と違いエージェント（claude-code-action）を維持しています（ワンショット QA 化 = `claude-qa.yml` を #50 で評価中）。
 
 **必要なシークレット:**
 - `anthropic_api_key`: Console 発行の `ANTHROPIC_API_KEY`
 
 **必要な権限:** `contents: read` / `pull-requests: write` / `issues: write` / `id-token: write`。
+
+### claude-qa.yml
+
+`@claude` メンションに **ワンショット**（Messages API 1回、エージェントループなし）で回答します。`claude-mention.yml` の置き換え候補として #50 で評価中で、当面はこの repo の `claude-mention-self.yml` でエージェント版と併走させて回答品質・所要時間を比較します。
+
+**仕組み（自己完結）:** イベント解析 → 文脈収集（PR→diff／Issue→本文／レビューコメント→対象 file/line＋スレッド／会話履歴）→ Messages API 1回 → 返信投稿（レビューコメントにはスレッド返信、それ以外は issue コメント）＋👀 リアクション。checkout もエージェントも無いため、構造的に編集・コミット不能です。
+
+**`claude-mention.yml` との違い:**
+- リポジトリの read/search はできず、渡された文脈のみで回答（不足時は何が分かれば答えられるかを明示）
+- OIDC（`id-token: write`）・max-turns・セッション暴走の懸念が無く、高速・低コスト
+- `@claude` 検出と author 権限ガードは caller の `if:` で行う（claude-mention と同一）
+
+**入力パラメータ:**
+| パラメータ | 必須 | デフォルト | 説明 |
+|-----------|:----:|-----------|------|
+| `model` | No | `claude-sonnet-4-6` | Messages API に渡すモデルコード |
+| `language` | No | `日本語` | 応答の言語 |
+| `timeout_minutes` | No | `10` | ジョブタイムアウト（分） |
+
+**必要なシークレット:**
+- `anthropic_api_key`: Console 発行の `ANTHROPIC_API_KEY`
+
+**必要な権限:** `contents: read` / `pull-requests: write` / `issues: write`（`id-token` 不要）。
 
 ### create-next-draft.yml
 


### PR DESCRIPTION
Resolve #50

## 概要

#50 の保留時に確定した方針（方式2: 専用の小さな QA パス）に沿って、`@claude` メンションに **ワンショット（Messages API 1回・エージェントなし）** で回答する reusable workflow `claude-qa.yml` を新設し、この repo の self caller でエージェント版と併走させる実機比較（A/B）体制を作ります。

## 変更内容

### `claude-qa.yml`（新規 reusable）

確定方針どおり、plumbing を自己完結で持ちます:

- **イベント解析**: `issue_comment` / `pull_request_review_comment` / `issues` (opened)
- **文脈収集**: PR→diff（取得不能な巨大 diff はファイル一覧にフォールバック）／Issue→本文／レビューコメント→対象 file/line＋diff hunk＋スレッド／会話履歴（直近20件）。セクション別＋全体（120k 文字）で切り詰め
- **Messages API 1回**: `fetch` で直接呼び出し（`max_tokens: 8192`、stop_reason=max_tokens 時は注記を付加）
- **投稿＋👀**: レビューコメントにはスレッド返信（`createReplyForReviewComment`、thread root を解決）、それ以外は `issues.createComment`。受付時に eyes リアクション
- **助言のみを構造で担保**: checkout もエージェントも無いため編集・コミットは構造的に不可能。OIDC/`id-token` 不要、max-turns・暴走の懸念なし
- `@claude` 検出＋author 権限ガードは caller の `if:` をそのまま流用（claude-mention と同一）
- reviewer action（`ai-academic-paper-reviewer`）の一般化はしない（確定方針どおり）

### `claude-mention-self.yml`（A/B 評価）

この repo での `@claude` メンションで **エージェント版（claude-mention.yml）とワンショット版（claude-qa.yml）の両方が回答**します。同一の質問で回答品質・所要時間を比較するための評価期間限定の構成です（ワンショット側の回答にはフッタで識別表示）。配布用 caller（`scripts/callers/claude-mention.yml`）は変更しません。

### ドキュメント

- README: workflow 一覧に `claude-qa.yml` を追加（評価中である旨を明記）、詳細セクションを追加
- `claude-mention.yml` ヘッダ: ワンショット QA の参照先を更新

## 検証

- `actionlint`（v1.7.12、CI と同じ）: 変更3ファイルすべてパス
- 埋め込み github-script JS の構文チェック: パス

## 評価の進め方（マージ後）

1. この repo の Issue/PR で代表質問（論文構成/本文・コード diff 近傍・横断コード）を `@claude` に投げ、両者の回答を比較
2. ワンショットで十分なら、別 PR で配布用 caller を `claude-qa.yml` に移行し claude-code-action を撤廃。不十分な領域があれば #50 に方針を明記

> [!NOTE]
> 本 PR のマージで #50 が自動クローズされます。受け入れ条件のうち「実機比較」はマージ後に行うため、比較完了まで issue を open に保ちたい場合は本文の `Resolve` を `Refs` に変更してください。
