### PR TITLE
ci: bump latest OTP to 29.0.2 and Elixir to 1.20.1

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -24,12 +24,12 @@ on:
         type: string
       otp-version-latest:
         description: 'Latest OTP version'
-        default: '28.5'
+        default: '29.0.2'
         required: false
         type: string
       elixir-version-latest:
         description: 'Latest Elixir version'
-        default: '1.19.5'
+        default: '1.20.1'
         required: false
         type: string
       dialyzer-enabled:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,12 +13,12 @@ on:
     inputs:
       otp-version:
         description: 'OTP version'
-        default: '28.5'
+        default: '29.0.2'
         required: false
         type: string
       elixir-version:
         description: 'Elixir version'
-        default: '1.19.5'
+        default: '1.20.1'
         required: false
         type: string
       dependency-audit-timeout:


### PR DESCRIPTION
## 概要

再利用ワークフローの「latest」OTP/Elixir デフォルトを更新する。

| ファイル | input | 変更前 → 変更後 |
|---|---|---|
| `elixir-ci.yml` | `otp-version-latest` | `28.5` → `29.0.2` |
| `elixir-ci.yml` | `elixir-version-latest` | `1.19.5` → `1.20.1` |
| `security.yml` | `otp-version` | `28.5` → `29.0.2` |
| `security.yml` | `elixir-version` | `1.19.5` → `1.20.1` |

LTS 側（`27.3.4.4` / `1.17.3`）は据え置き。

## 補足

- Elixir は `otp-version` と併せて指定すれば setup-beam が OTP メジャー対応ビルドを自動解決するため、`-otp-29` サフィックスは付けず既存表記と揃えて `1.20.1` とした。
- caller リポジトリ（tenbin_dns / tdig / tenbin_ex / tenbin_cache）は `with:` でバージョンを上書きしておらず本デフォルトを使用する。**反映には merge 後に `v1` タグの張り直しが必要**。
- elixir_dnstap は `@v1.0.0` を pin しているため、別途 `@v1` への変更が必要（本 PR スコープ外）。
- 各 release.yml のビルド用バージョン（`27.0` / `1.18.3`）は CI と独立のため本 PR では変更しない。

## 検証

- `actionlint` で両ファイル green（exit 0）。
- ⚠️ 実走確認は caller での fresh run（`v1` タグ更新後）で行う必要がある。
