### PR TITLE
docs: reorder LaTeX ecosystem table for student readability

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -45,14 +45,16 @@ graph LR
 
 | プロジェクト | 役割 |
 |---|---|
-| [latex-ecosystem](https://github.com/smkwlab/latex-ecosystem) | LaTeX テンプレート群とツールの全体管理 |
-| [latex-environment](https://github.com/smkwlab/latex-environment) | Dev Container ベースの再現可能な TeX 執筆環境 |
 | [latex-template](https://github.com/smkwlab/latex-template) | 汎用 LaTeX ドキュメントテンプレート |
+| [ise-report-template](https://github.com/smkwlab/ise-report-template) | 情報科学演習レポート用テンプレート（HTML5） |
 | [sotsuron-template](https://github.com/smkwlab/sotsuron-template) | 卒業論文テンプレート（draft ブランチ運用） |
 | [poster-template](https://github.com/smkwlab/poster-template) | 学会発表用 A0 ポスターテンプレート（tikzposter・日本語対応） |
-| [ise-report-template](https://github.com/smkwlab/ise-report-template) | 情報科学演習レポート用テンプレート（HTML5） |
-| [latex-release-action](https://github.com/smkwlab/latex-release-action) | LaTeX ビルド & PDF リリースを自動化する GitHub Action |
 | [split-sentences](https://github.com/smkwlab/split-sentences) | LaTeX 文書を 1 文 1 行に整形し diff を見やすくするツール |
+| [texlive-ja-textlint](https://github.com/smkwlab/texlive-ja-textlint) | 日本語 LaTeX コンパイル用の Docker イメージ（TeX Live + textlint）。下記環境の土台 |
+| [latex-environment](https://github.com/smkwlab/latex-environment) | Dev Container ベースの再現可能な TeX 執筆環境（各テンプレートに組み込まれ自動的に使われる） |
+| [aldc](https://github.com/smkwlab/aldc) | 既存テンプレートに LaTeX 用 Dev Container を追加する CLI ツール |
+| [latex-release-action](https://github.com/smkwlab/latex-release-action) | LaTeX ビルド & PDF リリースを自動化する GitHub Action |
+| [latex-ecosystem](https://github.com/smkwlab/latex-ecosystem) | LaTeX テンプレート群とツールの全体管理 |
 
 ---
 


### PR DESCRIPTION
## 概要

組織プロフィール (\`profile/README.md\`) の「文書作成エコシステム」の表を、主たる利用者である**学生にとって分かりやすい順番**に並べ替え、論文 (toshi-iot74) の構成図・表1 を参考に不足コンポーネントを補いました。

## 変更内容

- **並べ替え**: 管理リポジトリ先頭の構成をやめ、学生が実際に触る順に再構成
  1. 直接書くテンプレート: latex-template → ise-report → sotsuron → poster
  2. 執筆支援ツール: split-sentences
  3. 裏方の基盤（土台→環境→導入→CI→管理）: texlive-ja-textlint → latex-environment → aldc → latex-release-action → latex-ecosystem
- **追加**: \`texlive-ja-textlint\`（組版の土台 Docker イメージ）、\`aldc\`（DevContainer 導入 CLI）
- **説明の追記**: \`latex-environment\` に「各テンプレートに組み込まれ自動的に使われる」、\`texlive-ja-textlint\` に「下記環境の土台」

## 補足

- \`latex-environment\` は学生が直接開くより各テンプレート経由で自動利用されるため、裏方グループへ移動
- \`wr-template\` の追加も検討したが非公開リポジトリのため見送り
- 運用ツール（thesis-management-tools / thesis-student-registry）は学生向けプロフィールの趣旨に合わせて今回は対象外

## 品質確認

- 表内リンク先リポジトリ全11件が HTTP 200（公開）であることを確認済み