### PR TITLE
Pin third-party GitHub Actions to commit SHAs (E-3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Keep SHA-pinned third-party GitHub Actions up to date.
+  # Actions are pinned to full commit SHAs (see .github/workflows/*.yml);
+  # Dependabot bumps the SHA and the trailing "# vX.Y.Z" comment together.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Gemini Review Bot
         if: steps.check-key.outputs.skip != 'true'
-        uses: toshi0806/ai-reviewer@v1
+        uses: toshi0806/ai-reviewer@1808b48b8fc0c94daa8a829b0be13326df0eff70 # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/auto-final-merge.yml
+++ b/.github/workflows/auto-final-merge.yml
@@ -21,7 +21,7 @@ jobs:
   create-pr-to-main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ github.token }}

--- a/.github/workflows/claude-qa.yml
+++ b/.github/workflows/claude-qa.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Answer with one Messages API call
         if: steps.check-key.outputs.skip != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
           QA_MODEL: ${{ inputs.model }}

--- a/.github/workflows/create-next-draft.yml
+++ b/.github/workflows/create-next-draft.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ github.token }}

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -56,16 +56,16 @@ jobs:
 
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         otp-version: ${{ inputs.otp-version-latest }}
         elixir-version: ${{ inputs.elixir-version-latest }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -99,23 +99,23 @@ jobs:
 
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         otp-version: ${{ matrix.otp }}
         elixir-version: ${{ matrix.elixir }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
 
     - name: Restore build cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: _build
         key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
@@ -131,7 +131,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.primary
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         # For private repositories, set CODECOV_TOKEN secret in your repository
         # See: https://docs.codecov.com/docs/github-actions#using-private-repositories
@@ -142,7 +142,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Upload coverage reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: always()
       with:
         name: coverage-${{ matrix.otp }}-${{ matrix.elixir }}
@@ -161,23 +161,23 @@ jobs:
 
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         otp-version: ${{ inputs.otp-version-latest }}
         elixir-version: ${{ inputs.elixir-version-latest }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
 
     - name: Restore PLT cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: plt_cache
       with:
         path: priv/plts
@@ -230,7 +230,7 @@ jobs:
 
     - name: Create GitHub Issue for Dialyzer failures
       if: steps.dialyzer.outputs.result == 'failure'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         DIALYZER_OUTPUT: ${{ steps.read_output.outputs.dialyzer_output }}
       with:
@@ -301,7 +301,7 @@ jobs:
 
     - name: Close Dialyzer issues on success
       if: steps.dialyzer.outputs.result == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           // Close any existing Dialyzer issues if analysis passed

--- a/.github/workflows/html-validation.yml
+++ b/.github/workflows/html-validation.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js for additional tools
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/latex-build-modified.yml
+++ b/.github/workflows/latex-build-modified.yml
@@ -24,7 +24,7 @@ jobs:
       files: ${{ steps.set-files.outputs.files }}
       has_files: ${{ steps.set-files.outputs.has_files }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 2
 
@@ -57,7 +57,7 @@ jobs:
     container: ghcr.io/smkwlab/texlive-ja-textlint:2025g
     if: needs.find-modified-tex.outputs.has_files == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Prepare release name
         id: release-name

--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Build and Release LaTeX Documents
         uses: smkwlab/latex-release-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.7
+        uses: rhysd/actionlint@03d0035246f3e81f36aed592ffb4bebf33a03106 # v1.7.7

--- a/.github/workflows/prevent-draft-merge.yml
+++ b/.github/workflows/prevent-draft-merge.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,16 +44,16 @@ jobs:
 
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         otp-version: ${{ inputs.otp-version }}
         elixir-version: ${{ inputs.elixir-version }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -80,12 +80,12 @@ jobs:
 
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Scan for secrets in codebase
-      uses: trufflesecurity/trufflehog@v3.88.0
+      uses: trufflesecurity/trufflehog@ddc015e5ed99942b2253d8ea16a0586a01ef2ab1 # v3.88.0
       with:
         path: ./
         base: ${{ github.event.before || 'HEAD~1' }}


### PR DESCRIPTION
## Summary

Supply-chain / CI hardening — **E-3** of the ecosystem security review tracking issue (#69).

Pins every **third-party** GitHub Action referenced by a mutable tag to a full commit SHA, each with a trailing `# vX.Y.Z` comment so the version stays legible and Dependabot can bump it. Also adds `.github/dependabot.yml` so the pins are maintained automatically instead of drifting.

## Pinned actions

| Action | Was | Now (SHA) |
|---|---|---|
| `actions/checkout` | `@v4` / `@v5` | `34e1148…` (v4.3.1) / `93cb6ef…` (v5.0.1) |
| `actions/cache` | `@v4` | `0057852…` (v4.3.0) |
| `actions/upload-artifact` | `@v4` | `ea165f8…` (v4.6.2) |
| `actions/github-script` | `@v7` | `f28e40c…` (v7.1.0) |
| `actions/setup-node` | `@v4` | `49933ea…` (v4.4.0) |
| `actions/setup-python` | `@v5` | `a26af69…` (v5.6.0) |
| `erlef/setup-beam` | `@v1` | `54075bc…` (v1.24.1) |
| `codecov/codecov-action` | `@v4` | `b9fd7d1…` (v4.6.0) |
| `rhysd/actionlint` | `@v1.7.7` | `03d0035…` (v1.7.7) |
| `trufflesecurity/trufflehog` | `@v3.88.0` | `ddc015e…` (v3.88.0) |
| `toshi0806/ai-reviewer` | `@v1` | `1808b48…` (v1) |

`dawidd6/action-send-mail` was already SHA-pinned.

## Scope note

smkwlab-owned actions (`ai-academic-paper-reviewer@v1.9`, `latex-release-action@v3`) are intentionally left on tags here — the reviewer's `@v1` force-push / immutable-tag hygiene is tracked separately as **E-4** in #69, and pinning consumers to a SHA is the follow-up once that flow is fixed.

## Verification

- `actionlint` 1.7.12 → exit 0 on all workflows
- All SHAs resolved from the GitHub API for the referenced tag
- YAML parse-checked

Refs #69 (E-3). Tracking issue stays open — do not close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)