### PR TITLE
Pin org-owned latex-release-action to immutable v3.3.0

### DIFF
--- a/.github/workflows/latex-build-modified.yml
+++ b/.github/workflows/latex-build-modified.yml
@@ -74,7 +74,7 @@ jobs:
 
           echo "release_name=${first_file} Weekly Report" >> "$GITHUB_OUTPUT"
 
-      - uses: smkwlab/latex-release-action@v3
+      - uses: smkwlab/latex-release-action@v3.3.0
         with:
           files: ${{ needs.find-modified-tex.outputs.files }}
           release_name: ${{ steps.release-name.outputs.release_name }}

--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Build and Release LaTeX Documents
-        uses: smkwlab/latex-release-action@v3
+        uses: smkwlab/latex-release-action@v3.3.0
         env:
           GH_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary

Pin the org-owned action `smkwlab/latex-release-action` from the moving major tag `@v3` to the immutable version tag `@v3.3.0` for supply-chain hardening (follow-up to #69, items 2/3/5).

- `v3.3.0` resolves to the **same commit** (`7ded9ae`) as `@v3`, so this is behavior-preserving — it only removes reliance on a mutable tag.
- Applied in `latex-build.yml` and `latex-build-modified.yml`.

## Scope notes

- Third-party actions in this repo are **already SHA-pinned** and `.github/dependabot.yml` **already exists** — no changes there.
- Reusable `smkwlab/.github/.github/workflows/*.yml@v1` refs are **intentionally left on @v1** (the org's shared-CI channel). `smkwlab/ai-academic-paper-reviewer@v1.9` and local `./…` refs are likewise untouched.

## Validation

- `actionlint -shellcheck= -pyflakes=` on both changed files: clean (exit 0).
- YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
