### PR TITLE
Renovate: keep html-validation Python and texlive image pinned

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,13 +8,11 @@
   "packageRules": [
     {
       "description": "Keep the html-validation Python runtime pinned (3.11 was chosen deliberately). A new Python minor may lack html5validator / tool support and CI does not exercise it here, so bump it manually rather than via the grouped auto-merge.",
-      "matchManagers": ["github-actions"],
       "matchDepNames": ["python"],
       "enabled": false
     },
     {
       "description": "texlive-ja-textlint uses a custom year+revision tag (e.g. 2025g) that Renovate mis-orders (2025 is not newer than 2025g). Bump this image tag manually.",
-      "matchManagers": ["github-actions"],
       "matchPackageNames": ["ghcr.io/smkwlab/texlive-ja-textlint"],
       "enabled": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,19 @@
     "github>smkwlab/.github#v1",
     "github>smkwlab/.github:github-actions#v1"
   ],
-  "enabledManagers": ["github-actions"]
+  "enabledManagers": ["github-actions"],
+  "packageRules": [
+    {
+      "description": "Keep the html-validation Python runtime pinned (3.11 was chosen deliberately). A new Python minor may lack html5validator / tool support and CI does not exercise it here, so bump it manually rather than via the grouped auto-merge.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["python"],
+      "enabled": false
+    },
+    {
+      "description": "texlive-ja-textlint uses a custom year+revision tag (e.g. 2025g) that Renovate mis-orders (2025 is not newer than 2025g). Bump this image tag manually.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["ghcr.io/smkwlab/texlive-ja-textlint"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Addresses the review on **#74** (Renovate's grouped github-actions update). That "safe" grouped PR swept in two risky non-action changes that this repo's PR CI (actionlint + review) does **not** exercise:

- **`python 3.11 → 3.14`** (`html-validation.yml`) — the workflow pip-installs `html5validator`; Python 3.14 is very new and tool support is uncertain. `3.11` was a deliberate pin. (Flagged by the AI reviewer on #74.)
- **`ghcr.io/smkwlab/texlive-ja-textlint 2025g → 2025`** (`latex-build-modified.yml`) — Renovate mis-orders the custom `year+revision` tag (`2025` is **not** newer than `2025g`), i.e. a regression.

## Change

Add two `packageRules` to this repo's `renovate.json` disabling Renovate updates for the pinned Python runtime and the custom-tagged texlive image (both to be bumped manually). This is a **repo-level** config (read directly by Renovate for this repo — no `v1` move needed), so the grouped auto-merge PR will only carry the genuinely-safe action bumps (`actionlint`, `action-send-mail`, `trufflehog`).

After this merges, #74 will be closed and re-created by Renovate with only the safe actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)