### PR TITLE
Revert Python 3.14 and texlive 2025 bumps from #74

### DIFF
--- a/.github/workflows/html-validation.yml
+++ b/.github/workflows/html-validation.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.14'
+          python-version: '3.11'
 
       - name: Install HTML validation tools
         run: |

--- a/.github/workflows/latex-build-modified.yml
+++ b/.github/workflows/latex-build-modified.yml
@@ -54,7 +54,7 @@ jobs:
   build-and-release:
     needs: find-modified-tex
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2025g
     if: needs.find-modified-tex.outputs.has_files == 'true'
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
## Summary

#74 (grouped github-actions auto-merge) merged **before its rebase could drop** two risky non-action changes that CI here doesn't exercise. Restore them on main:

- `html-validation.yml`: `python-version` **3.14 → 3.11** — 3.14 is too new for the pip `html5validator` tooling; 3.11 was the deliberate pin.
- `latex-build-modified.yml`: `texlive-ja-textlint` **2025 → 2025g** — Renovate mis-ordered the custom `year+revision` tag (2025 is not newer than 2025g), a regression.

The **safe** action bumps #74 also brought in (`actionlint` v1.7.12, `action-send-mail` v3.12.0, `trufflehog` v3.95.8) are **kept**.

Renovate will not re-propose the two reverted deps — they're disabled in `renovate.json` via #77.

`actionlint` clean. Refs #74 / #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)