### PR TITLE
Update texlive-ja-textlint to 2026a; re-enable Renovate with loose versioning

### DIFF
--- a/.github/workflows/latex-build-modified.yml
+++ b/.github/workflows/latex-build-modified.yml
@@ -54,7 +54,7 @@ jobs:
   build-and-release:
     needs: find-modified-tex
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025g
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
     if: needs.find-modified-tex.outputs.has_files == 'true'
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,10 @@
       "enabled": false
     },
     {
-      "description": "texlive-ja-textlint uses a custom year+revision tag (e.g. 2025g) that Renovate mis-orders (2025 is not newer than 2025g). Bump this image tag manually.",
+      "description": "texlive-ja-textlint uses a custom YYYY[revision-letter] tag scheme (e.g. 2025g, 2026a). The default docker versioning mis-orders it (it treated bare 2025 as newer than 2025g). Use loose versioning and restrict candidates to plain year tags so Renovate orders them correctly and ignores the alpine/debian/amd64/test/latest variants.",
       "matchPackageNames": ["ghcr.io/smkwlab/texlive-ja-textlint"],
-      "enabled": false
+      "versioning": "loose",
+      "allowedVersions": "/^20\\d{2}[a-z]?$/"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two things, both about the `ghcr.io/smkwlab/texlive-ja-textlint` container in `latex-build-modified.yml`:

1. **Bump `2025g → 2026a`** — the current latest plain tag. `2025g` was 3 revisions behind (`2025h`, `2025i`, `2026a`, confirmed from the ghcr tag list).
2. **Re-enable Renovate auto-updates, correctly.** In #77 I *disabled* updates for this image because Renovate's default docker versioning mis-ordered the custom `YYYY[letter]` scheme (it proposed the `2025g → 2025` **regression**). Replace that disable rule with:
   ```json
   { "matchPackageNames": ["ghcr.io/smkwlab/texlive-ja-textlint"],
     "versioning": "loose",
     "allowedVersions": "/^20\\d{2}[a-z]?$/" }
   ```
   `loose` orders `2025g < 2025h < 2025i < 2026a` correctly; `allowedVersions` restricts candidates to plain year tags (ignoring `alpine`/`debian`/`amd64`/`test`/`latest`).

## Why it wasn't auto-updating (answer to the question)

- `.github` only came under Renovate in the consolidation (#73), so this image had **never** been auto-managed before.
- Its **first** Renovate attempt mis-ordered the custom tags (default docker versioning), and I **disabled** it in #77 to stop the regression — so it's been proposing nothing by design.

## Self-verification

`2026a` is the max plain tag, so after this a correct Renovate run should propose **nothing** further for this image — if it ever suggests a "downgrade", the versioning is still wrong and we revisit. A year bump (e.g. a future `2027a`) will come as an individual (major) PR to review; within-year revisions may auto-merge per the org policy.

`actionlint` clean. Follow-up to #74 / #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)