### PR TITLE
Bump actions/cache to v6.1.0 and codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -65,7 +65,7 @@ jobs:
         elixir-version: ${{ inputs.elixir-version-latest }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -108,14 +108,14 @@ jobs:
         elixir-version: ${{ matrix.elixir }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
 
     - name: Restore build cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: _build
         key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
@@ -131,7 +131,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.primary
-      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         # For private repositories, set CODECOV_TOKEN secret in your repository
         # See: https://docs.codecov.com/docs/github-actions#using-private-repositories
@@ -170,14 +170,14 @@ jobs:
         elixir-version: ${{ inputs.elixir-version-latest }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
 
     - name: Restore PLT cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: plt_cache
       with:
         path: priv/plts

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,7 +53,7 @@ jobs:
         elixir-version: ${{ inputs.elixir-version }}
 
     - name: Restore dependencies cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
Both were held for consumer-side validation (they live in the reusable `elixir-ci.yml`/`security.yml` that .github's own CI doesn't run).

**Validated on tenbin_dns PR #125** (callers pointed at a .github test branch with these bumps): all CI jobs green, and codecov v7's *Upload coverage to Codecov* step **succeeded** (real upload). Supersedes Renovate #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)