### PR TITLE
Bump actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -142,7 +142,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Upload coverage reports
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: coverage-${{ matrix.otp }}-${{ matrix.elixir }}


### PR DESCRIPTION
In reusable `elixir-ci.yml` (coverage upload). Validated on tenbin_dns #126: "Upload coverage reports" step succeeded on both OTP matrices with v7. Supersedes Renovate #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)