### PR TITLE
Bump action-send-mail to v18 and html-validation Node to 24

### DIFF
--- a/.github/workflows/html-validation.yml
+++ b/.github/workflows/html-validation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js for additional tools
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -79,7 +79,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Send notification email to lab ML
-        uses: dawidd6/action-send-mail@2cea9617b09d79a095af21254fbcb7ae95903dde  # v3.12.0
+        uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59  # v18
         with:
           server_address: ${{ secrets.SMTP_SERVER }}
           server_port: ${{ secrets.SMTP_PORT }}


### PR DESCRIPTION
Reviewed Renovate #88 / #89.

**action-send-mail v3.12.0 → v18**: verified all majors v3..v18 — the only breaking change affecting our usage is v12's `from` format requirement. `SMTP_FROM` produces `From: github-notify@smkwlab.net` (bare email) → compliant. Other inputs stable. (Email send runs only on real PR events, so v18 delivery is confirmed on the next ML notification post-deploy.)

**html-validation Node 20 → 24**: Node 24 is current LTS (since 2025-10), Node 20 is EOL (2026-04); node is only used for htmlhint + a trivial CSS check → fine on 24.

Supersedes #88 / #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)