### PR TITLE
fix(elixir-ci): run quality checks on the LTS Elixir lane

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -58,11 +58,16 @@ jobs:
     - name: Set up Git repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+    # Quality checks (format / compile / credo) run on the LTS lane: credo 1.7.x
+    # crashes tokenizing regex sigils (~r/.../) on newer Elixir (smkwlab/.github#94),
+    # and credo's version is controlled by each caller's mix.lock, not this
+    # workflow. Real latest-Elixir compatibility is still covered by the test
+    # matrix below (which compiles and tests on the latest lane).
     - name: Set up Elixir
       uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
-        otp-version: ${{ inputs.otp-version-latest }}
-        elixir-version: ${{ inputs.elixir-version-latest }}
+        otp-version: ${{ inputs.otp-version-lts }}
+        elixir-version: ${{ inputs.elixir-version-lts }}
 
     - name: Restore dependencies cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## 概要

reusable workflow `elixir-ci.yml` の **Code Quality** ジョブを **LTS レーン(Elixir 1.17.3)** で実行するように変更します。Resolves #94。

## 背景

Code Quality ジョブは `mix format` / `mix compile --warnings-as-errors` / `mix credo --strict` を **latest レーン(1.20.1)** で実行していました。credo 1.7.x が Elixir 1.20 の regex sigil(`~r/.../`)トークンをパースできず crash します:

```
** (FunctionClauseError) no function clause matching in Credo.Code.Token.position/1
    (credo 1.7.12) lib/credo/code/token.ex:37
```

credo のバージョンは各利用リポジトリの `mix.lock` 由来で reusable workflow からは固定できないため、workflow 側で打てる手は「quality チェックを走らせる Elixir バージョン」の変更のみです。

## 変更

- `quality` ジョブの `setup-beam` を `inputs.otp-version-latest` / `elixir-version-latest` → `*-lts` に変更(7 insertions, 2 deletions)
- `test` マトリクス(両レーン)・`dialyzer`(latest)は不変

trade-off: latest レーンでの `--warnings-as-errors` は失われますが、latest Elixir での実コンパイル・テストは `test` マトリクスで引き続き担保されます。新規ジョブを増やさないため、全利用リポジトリの required check 面は変わりません。

## 検証(E2E)

fix ブランチを `smkwlab/ecosystem-manager`(sigil crash の初出リポジトリ)の CI から参照して `workflow_dispatch` 実行:

| ジョブ | 結果 |
|---|---|
| ci / Code Quality(credo, LTS) | ✅ success |
| ci / Test (1.17.3) | ✅ success |
| ci / Test (1.20.1) | ✅ success |
| ci / Dialyzer | ⏭ skipped(dispatch のため。`push` 時のみ実行) |

以前 crash していた credo が LTS レーンで pass することを実リポジトリで確認済み。検証用の throwaway ブランチは削除済みです。

## merge 後の必須手順 ⚠️

本 workflow は `@v1` タグ参照です。**merge 後に `v1` タグをこの修正コミットへ移動**しないと、ecosystem-manager 等の `@v1` 利用リポジトリには反映されません(タグ移動は merge 前には行いません)。

Claude-Session: https://claude.ai/code/session_01Jnvhs3pKABL6vvxj9a5ueb