### PR TITLE
feat: add sync-next-draft reusable workflow

### DIFF
--- a/.github/workflows/prevent-draft-merge.yml
+++ b/.github/workflows/prevent-draft-merge.yml
@@ -75,13 +75,16 @@ jobs:
 
           # Allow draft-to-draft sync PRs (e.g. created by
           # sync-next-draft.yml to carry accepted review suggestions
-          # into the next draft branch)
+          # into the next draft branch). Both head and base must match
+          # a draft pattern.
           echo "::debug::Base branch: $BASE_REF"
-          if [[ "$BASE_REF" =~ ^[0-9]+(st|nd|rd|th)-draft$ ]] || \
-             [[ "$BASE_REF" =~ ^abstract-[0-9]+(st|nd|rd|th)$ ]]; then
+          if { [[ "$BRANCH_NAME" =~ ^[0-9]+(st|nd|rd|th)-draft$ ]] || \
+               [[ "$BRANCH_NAME" =~ ^abstract-[0-9]+(st|nd|rd|th)$ ]]; } && \
+             { [[ "$BASE_REF" =~ ^[0-9]+(st|nd|rd|th)-draft$ ]] || \
+               [[ "$BASE_REF" =~ ^abstract-[0-9]+(st|nd|rd|th)$ ]]; }; then
             { echo "is_draft=false"; echo "draft_type=sync"; } >> "$GITHUB_OUTPUT"
             echo "Draft-to-draft sync PR - merge allowed"
-            echo "::notice::Base branch is a draft branch ($BASE_REF) - sync PR"
+            echo "::notice::Head and base are both draft branches - sync PR"
             exit 0
           fi
 

--- a/.github/workflows/prevent-draft-merge.yml
+++ b/.github/workflows/prevent-draft-merge.yml
@@ -1,4 +1,3 @@
----
 # Reusable Workflow: Prevent Draft Branch Merge
 #
 # This workflow prevents accidental merging of draft branches.
@@ -44,6 +43,7 @@ jobs:
         id: check-draft
         env:
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set -e
 
@@ -71,6 +71,18 @@ jobs:
               echo "::notice::Final submission tag: $FINAL_TAG"
               exit 0
             fi
+          fi
+
+          # Allow draft-to-draft sync PRs (e.g. created by
+          # sync-next-draft.yml to carry accepted review suggestions
+          # into the next draft branch)
+          echo "::debug::Base branch: $BASE_REF"
+          if [[ "$BASE_REF" =~ ^[0-9]+(st|nd|rd|th)-draft$ ]] || \
+             [[ "$BASE_REF" =~ ^abstract-[0-9]+(st|nd|rd|th)$ ]]; then
+            { echo "is_draft=false"; echo "draft_type=sync"; } >> "$GITHUB_OUTPUT"
+            echo "Draft-to-draft sync PR - merge allowed"
+            echo "::notice::Base branch is a draft branch ($BASE_REF) - sync PR"
+            exit 0
           fi
 
           # Branch name validation
@@ -132,6 +144,7 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           IS_FINAL: ${{ steps.check-draft.outputs.is_final_submission }}
           FINAL_TAG: ${{ steps.check-draft.outputs.final_tag }}
+          DRAFT_TYPE: ${{ steps.check-draft.outputs.draft_type }}
         run: |
           BRANCH_NAME="$HEAD_REF"
 
@@ -139,6 +152,9 @@ jobs:
             echo "Final submission branch - merge allowed"
             echo "Branch name: $BRANCH_NAME"
             echo "Final submission tag: $FINAL_TAG"
+          elif [[ "$DRAFT_TYPE" == "sync" ]]; then
+            echo "Draft-to-draft sync PR - merge allowed"
+            echo "Branch name: $BRANCH_NAME"
           else
             echo "Regular branch - merge allowed"
             echo "Branch name: $BRANCH_NAME"

--- a/.github/workflows/sync-next-draft.yml
+++ b/.github/workflows/sync-next-draft.yml
@@ -1,0 +1,206 @@
+# Reusable Workflow: Sync Next Draft Branch
+#
+# When commits are pushed to a draft branch (e.g. a student accepts
+# review suggestions on its PR), this workflow merges them into the
+# following draft branch(es) so students always continue writing on
+# top of the reviewed text.
+#
+# Pushes made with GITHUB_TOKEN do not trigger new workflow runs, so a
+# single run walks the whole chain (1st-draft -> 2nd-draft -> ...).
+# On merge conflict, it opens a draft-to-draft sync PR (resolvable in
+# the browser) and notifies the review PR of the pushed branch.
+#
+# Use this from other repositories with:
+#
+#   on:
+#     push:
+#       branches:
+#         - '*-draft'
+#         - 'abstract-*'
+#   jobs:
+#     sync:
+#       permissions:
+#         contents: write
+#         pull-requests: write
+#       uses: smkwlab/.github/.github/workflows/sync-next-draft.yml@v1
+#
+name: Sync Next Draft Branch
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-next-branch:
+    runs-on: ubuntu-latest
+
+    # Defensive guard against bot loops (GITHUB_TOKEN pushes do not
+    # trigger workflows in the first place)
+    if: github.actor != 'github-actions[bot]'
+
+    concurrency:
+      group: sync-next-draft-${{ github.repository }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync pushed changes into following draft branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUSHED_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -eu
+
+          # Ordinal suffix for a number (1 -> 1st, 2 -> 2nd, ...)
+          ordinal() {
+            local n="$1"
+            local last_two=$((n % 100))
+            local last_one=$((n % 10))
+            if [[ $last_two -ge 11 && $last_two -le 13 ]]; then
+              echo "${n}th"
+            elif [[ $last_one -eq 1 ]]; then
+              echo "${n}st"
+            elif [[ $last_one -eq 2 ]]; then
+              echo "${n}nd"
+            elif [[ $last_one -eq 3 ]]; then
+              echo "${n}rd"
+            else
+              echo "${n}th"
+            fi
+          }
+
+          # Draft branch following the given one (empty if no draft pattern)
+          next_branch() {
+            local branch="$1"
+            if [[ "$branch" =~ ^([0-9]+)(st|nd|rd|th)-draft$ ]]; then
+              # Also covers the 0th-draft -> 1st-draft special case
+              echo "$(ordinal $((BASH_REMATCH[1] + 1)))-draft"
+            elif [[ "$branch" =~ ^abstract-([0-9]+)(st|nd|rd|th)$ ]]; then
+              echo "abstract-$(ordinal $((BASH_REMATCH[1] + 1)))"
+            fi
+          }
+
+          # Merge "from" into "into" and push; retry once on push race.
+          # Returns 1 on merge conflict, 2 when the push keeps failing.
+          sync_pair() {
+            local from="$1" into="$2" attempt
+            for attempt in 1 2; do
+              git fetch origin \
+                "+refs/heads/$from:refs/remotes/origin/$from" \
+                "+refs/heads/$into:refs/remotes/origin/$into"
+              git checkout -B "$into" "origin/$into"
+              if ! git merge --no-edit -m "Merge $from into $into (sync review suggestions)" "origin/$from"; then
+                git merge --abort || true
+                return 1
+              fi
+              if git push origin "$into"; then
+                return 0
+              fi
+              echo "Push of $into was rejected (concurrent update), retrying..."
+            done
+            return 2
+          }
+
+          conflict_pr_body() {
+            local from="$1" into="$2"
+            cat <<EOF
+          ## 前稿の変更を自動で取り込めませんでした
+
+          「$from」で受け入れた suggestion（レビューでの修正）を「$into」へ自動 merge しようとしましたが、同じ箇所が両方のブランチで編集されているため、自動では取り込めませんでした。
+
+          ### 対応手順（ブラウザだけで完結します）
+
+          1. この PR の下部にある **Resolve conflicts** ボタンを押す
+          2. エディタで \`<<<<<<<\` から \`>>>>>>>\` までの箇所を探し、残したい文になるように編集する
+          3. **Mark as resolved** を押してから **Commit merge** を押す
+          4. この PR を **Merge pull request** で merge する（この同期 PR は merge してかまいません）
+
+          merge が完了すると、以降の suggestion は再び自動で「$into」へ取り込まれます。
+          EOF
+          }
+
+          # On conflict: open a draft-to-draft sync PR and notify the
+          # review PR of the pushed branch.
+          handle_conflict() {
+            local from="$1" into="$2"
+            echo "::warning::Merge conflict while syncing $from into $into"
+
+            local sync_pr
+            sync_pr=$(gh pr list --head "$from" --base "$into" --state open \
+              --json number --jq '.[0].number // empty')
+
+            if [ -z "$sync_pr" ]; then
+              gh pr create --base "$into" --head "$from" \
+                --title "Sync review suggestions from $from into $into" \
+                --body "$(conflict_pr_body "$from" "$into")"
+              sync_pr=$(gh pr list --head "$from" --base "$into" --state open \
+                --json number --jq '.[0].number // empty')
+            fi
+
+            local review_pr
+            review_pr=$(gh pr list --head "$from" --state open \
+              --json number,baseRefName \
+              --jq "[.[] | select(.baseRefName != \"$into\")][0].number // empty")
+            if [ -n "$review_pr" ]; then
+              gh pr comment "$review_pr" --body "受け入れた suggestion を「$into」へ自動 merge できませんでした（コンフリクト）。同期 PR #$sync_pr を開き、「Resolve conflicts」で解決してから merge してください。"
+            fi
+
+            {
+              echo "## Sync stopped by merge conflict"
+              echo ""
+              echo "- $from -> $into: conflict, see sync PR #$sync_pr"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          current="$PUSHED_BRANCH"
+          synced=""
+
+          while true; do
+            next="$(next_branch "$current")"
+            if [ -z "$next" ]; then
+              echo "::notice::No next draft branch pattern for $current; done"
+              break
+            fi
+            if ! git ls-remote --exit-code --heads origin "$next" > /dev/null; then
+              echo "::notice::Next draft branch $next does not exist; done"
+              break
+            fi
+
+            status=0
+            sync_pair "$current" "$next" || status=$?
+
+            if [ "$status" -eq 1 ]; then
+              handle_conflict "$current" "$next"
+              exit 0
+            elif [ "$status" -ne 0 ]; then
+              echo "::error::Could not push $next (kept failing due to concurrent updates)"
+              exit 1
+            fi
+
+            echo "Synced $current -> $next"
+            synced="$synced $next"
+            current="$next"
+          done
+
+          if [ -n "$synced" ]; then
+            {
+              echo "## Synced draft branches"
+              echo ""
+              for b in $synced; do
+                echo "- $b"
+              done
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/sync-next-draft.yml
+++ b/.github/workflows/sync-next-draft.yml
@@ -96,8 +96,11 @@ jobs:
           # Merge "from" into "into" and push; retry once on push race.
           # Returns 1 on merge conflict, 2 when the push keeps failing.
           sync_pair() {
-            local from="$1" into="$2" attempt
-            for attempt in 1 2; do
+            local from="$1" into="$2"
+            for _ in 1 2; do
+              # (Re)start from the freshly fetched remote state; on a
+              # retry after a rejected push, checkout -B discards the
+              # previous local merge and redoes it on the new tip
               git fetch origin \
                 "+refs/heads/$from:refs/remotes/origin/$from" \
                 "+refs/heads/$into:refs/remotes/origin/$into"
@@ -143,17 +146,19 @@ jobs:
               --json number --jq '.[0].number // empty')
 
             if [ -z "$sync_pr" ]; then
-              gh pr create --base "$into" --head "$from" \
+              local pr_url
+              pr_url=$(gh pr create --base "$into" --head "$from" \
                 --title "Sync review suggestions from $from into $into" \
-                --body "$(conflict_pr_body "$from" "$into")"
-              sync_pr=$(gh pr list --head "$from" --base "$into" --state open \
-                --json number --jq '.[0].number // empty')
+                --body "$(conflict_pr_body "$from" "$into")")
+              sync_pr="${pr_url##*/}"
             fi
 
+            # The review PR of "from" is the open PR whose base is not a
+            # draft branch (draft-based PRs are sync PRs, also mid-chain)
             local review_pr
             review_pr=$(gh pr list --head "$from" --state open \
               --json number,baseRefName \
-              --jq "[.[] | select(.baseRefName != \"$into\")][0].number // empty")
+              --jq '[.[] | select(.baseRefName | test("^[0-9]+(st|nd|rd|th)-draft$|^abstract-[0-9]+(st|nd|rd|th)$") | not)][0].number // empty')
             if [ -n "$review_pr" ]; then
               gh pr comment "$review_pr" --body "受け入れた suggestion を「$into」へ自動 merge できませんでした（コンフリクト）。同期 PR #$sync_pr を開き、「Resolve conflicts」で解決してから merge してください。"
             fi

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ smkwlab organization の共通設定および Reusable Workflows を管理する
 | Workflow | 説明 | 用途 |
 |----------|------|------|
 | `create-next-draft.yml` | PR 作成時に次の draft ブランチを自動作成 | 卒論・ISE レポート |
+| `sync-next-draft.yml` | draft ブランチへの push（suggestion 受け入れ等）を後続の draft ブランチへ自動 merge | 卒論・ISE レポート |
 | `prevent-draft-merge.yml` | draft ブランチの誤マージを防止 | 卒論・ISE レポート |
 | `auto-final-merge.yml` | final-* タグ push 時に承認済み PR を自動マージ | 卒論テンプレート |
 | `ai-review.yml` | ワンショット LLM（Claude/Gemini）による PR 自動レビュー（CODE / ACADEMIC） | 全テンプレート |
@@ -384,9 +385,40 @@ draft ブランチからの PR 作成時に、次の draft ブランチを自動
 - `abstract-1st` → `abstract-2nd` → ...
 - `0th-draft` → `1st-draft`
 
+### sync-next-draft.yml
+
+draft ブランチへ push されたコミット（レビュー PR で suggestion を受け入れた場合を含む）を、後続の draft ブランチへ連鎖的に自動 merge します。PR 作成時に次稿ブランチが先行作成されるため、その後に受け入れた suggestion が次稿に反映されない問題（sotsuron-template#110）への対応です。
+
+**動作:**
+
+- `1st-draft` への push → `2nd-draft` が存在すれば merge → `3rd-draft` … と存在する限り伝播（GITHUB_TOKEN による push は新しい workflow run を発火しないため、1 回の実行でチェーン全体を処理）
+- コンフリクト時: 前稿→次稿の同期 PR（例: head `1st-draft` / base `2nd-draft`）を自動作成し、前稿のレビュー PR へコメントで通知。学生はブラウザの「Resolve conflicts」で解決して同期 PR を merge する（`prevent-draft-merge.yml` は draft→draft の同期 PR を許可）
+- 成功時は PR コメントしない（Actions の step summary にのみ記録）
+
+**caller 例:**
+
+```yaml
+name: Sync Suggestions to Next Draft
+on:
+  push:
+    branches:
+      - '*-draft'
+      - 'abstract-*'
+
+jobs:
+  sync:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: smkwlab/.github/.github/workflows/sync-next-draft.yml@v1
+```
+
+> [!NOTE]
+> `push` トリガーは **push されたブランチ上の**ワークフローファイルを参照します。既存リポジトリへ配布する際は default branch だけでなく、既存の draft ブランチにも caller を配置してください（`registry-manager propagate-workflow` 等で伝播）。
+
 ### prevent-draft-merge.yml
 
-draft ブランチの誤マージを防止します。`final-*` タグが付いている場合のみマージを許可。
+draft ブランチの誤マージを防止します。`final-*` タグが付いている場合のみマージを許可。また、base も draft ブランチである同期 PR（`sync-next-draft.yml` がコンフリクト時に作成）はマージを許可します。
 
 ### auto-final-merge.yml
 


### PR DESCRIPTION
## 概要

draft ブランチへの push (レビュー PR での suggestion 受け入れを含む) を、後続の draft ブランチへ連鎖的に自動 merge する再利用ワークフロー `sync-next-draft.yml` を追加します。

PR 作成時に `create-next-draft.yml` が次稿ブランチを先行作成するため、その後に受け入れた suggestion が次稿ブランチに反映されない問題 (smkwlab/sotsuron-template#110) への対応です。学生の手動操作 (smkwlab/sotsuron-template#111 のスクリプト案) を不要にします。

## 変更内容

### 新規: `.github/workflows/sync-next-draft.yml`

- `workflow_call` で提供。caller 側は draft ブランチへの `push` をトリガーに呼び出す (caller 例はファイルヘッダと README に記載)
- push されたブランチから後続ブランチ名を序数計算で求め、存在する限りチェーン merge (`1st-draft` → `2nd-draft` → `3rd-draft` → …)。GITHUB_TOKEN による push は新しい workflow run を発火しないため、1 回の実行でチェーン全体を処理
- **コンフリクト時**: 前稿→次稿の同期 PR (head=前稿 / base=次稿) を自動作成し、前稿のレビュー PR へコメントで通知。学生はブラウザの「Resolve conflicts」だけで解決可能。同一ペアの同期 PR が既に open の場合は再作成しない
- push の競合 (学生の同時 push) は 1 回リトライ
- `concurrency` で同一リポジトリ内の実行を直列化
- 成功時は PR コメントを出さない (step summary のみ。suggestion 受け入れごとのコメントはノイズになるため)

### 修正: `.github/workflows/prevent-draft-merge.yml`

base も draft ブランチである PR (上記の同期 PR) をマージ許可対象に追加。従来は head が draft パターンだと base を問わずブロックしていたため、同期 PR が誤ブロックされる問題への対応。既存の final-* タグ判定・draft ブロック動作は変更なし (非破壊)。

### ドキュメント: `README.md`

- PR レビューワークフロー表に `sync-next-draft.yml` を追加
- 詳細セクションを追加 (動作・caller 例・既存リポジトリ配布時は draft ブランチにも caller が必要な旨)
- `prevent-draft-merge.yml` の説明に同期 PR 許可を追記

## バージョニング

全ワークフローに対して非破壊 (新規追加 + 許可条件の追加) のため、merge 後に `v1.25.0` を発行し floating `v1` を付け替える想定です。

## 今後の展開 (別 PR / 別作業)

1. テンプレート (sotsuron-template / ise-report-template / latex-template) へ caller を追加
2. 今年度の k24rs*-ise-report1 リポジトリへ caller を配布 (default branch + 既存 draft ブランチ)
3. k19rs999-ise-report1 で E2E 検証
4. sotsuron-template#110 / #111 をクローズ

Refs: smkwlab/sotsuron-template#110