### PR TITLE
fix: restrict sync PR allowance to base == next draft of head

### DIFF
--- a/.github/workflows/prevent-draft-merge.yml
+++ b/.github/workflows/prevent-draft-merge.yml
@@ -73,18 +73,31 @@ jobs:
             fi
           fi
 
-          # Allow draft-to-draft sync PRs (e.g. created by
-          # sync-next-draft.yml to carry accepted review suggestions
-          # into the next draft branch). Both head and base must match
-          # a draft pattern.
+          # Allow draft-to-draft sync PRs created by sync-next-draft.yml:
+          # the base must be exactly the NEXT draft of the head branch
+          # (e.g. head 1st-draft -> base 2nd-draft). Review PRs go in the
+          # opposite direction (e.g. head 2nd-draft -> base 1st-draft)
+          # and stay blocked.
           echo "::debug::Base branch: $BASE_REF"
-          if { [[ "$BRANCH_NAME" =~ ^[0-9]+(st|nd|rd|th)-draft$ ]] || \
-               [[ "$BRANCH_NAME" =~ ^abstract-[0-9]+(st|nd|rd|th)$ ]]; } && \
-             { [[ "$BASE_REF" =~ ^[0-9]+(st|nd|rd|th)-draft$ ]] || \
-               [[ "$BASE_REF" =~ ^abstract-[0-9]+(st|nd|rd|th)$ ]]; }; then
+          ordinal() {
+            local n="$1" last_two last_one
+            last_two=$((n % 100)); last_one=$((n % 10))
+            if [[ $last_two -ge 11 && $last_two -le 13 ]]; then echo "${n}th"
+            elif [[ $last_one -eq 1 ]]; then echo "${n}st"
+            elif [[ $last_one -eq 2 ]]; then echo "${n}nd"
+            elif [[ $last_one -eq 3 ]]; then echo "${n}rd"
+            else echo "${n}th"; fi
+          }
+          NEXT_OF_HEAD=""
+          if [[ "$BRANCH_NAME" =~ ^([0-9]+)(st|nd|rd|th)-draft$ ]]; then
+            NEXT_OF_HEAD="$(ordinal $((BASH_REMATCH[1] + 1)))-draft"
+          elif [[ "$BRANCH_NAME" =~ ^abstract-([0-9]+)(st|nd|rd|th)$ ]]; then
+            NEXT_OF_HEAD="abstract-$(ordinal $((BASH_REMATCH[1] + 1)))"
+          fi
+          if [ -n "$NEXT_OF_HEAD" ] && [ "$BASE_REF" = "$NEXT_OF_HEAD" ]; then
             { echo "is_draft=false"; echo "draft_type=sync"; } >> "$GITHUB_OUTPUT"
             echo "Draft-to-draft sync PR - merge allowed"
-            echo "::notice::Head and base are both draft branches - sync PR"
+            echo "::notice::Base ($BASE_REF) is the next draft of head ($BRANCH_NAME) - sync PR"
             exit 0
           fi
 

--- a/.github/workflows/sync-next-draft.yml
+++ b/.github/workflows/sync-next-draft.yml
@@ -153,12 +153,14 @@ jobs:
               sync_pr="${pr_url##*/}"
             fi
 
-            # The review PR of "from" is the open PR whose base is not a
-            # draft branch (draft-based PRs are sync PRs, also mid-chain)
+            # The review PR of "from" is the open PR other than the sync
+            # PR itself. Note: its base may also be a draft branch (review
+            # PRs of 2nd and later drafts are based on the previous draft),
+            # so we only exclude the sync target here.
             local review_pr
             review_pr=$(gh pr list --head "$from" --state open \
               --json number,baseRefName \
-              --jq '[.[] | select(.baseRefName | test("^[0-9]+(st|nd|rd|th)-draft$|^abstract-[0-9]+(st|nd|rd|th)$") | not)][0].number // empty')
+              --jq "[.[] | select(.baseRefName != \"$into\")][0].number // empty")
             if [ -n "$review_pr" ]; then
               gh pr comment "$review_pr" --body "受け入れた suggestion を「$into」へ自動 merge できませんでした（コンフリクト）。同期 PR #$sync_pr を開き、「Resolve conflicts」で解決してから merge してください。"
             fi


### PR DESCRIPTION
## 概要

PR #98 のレビュー指摘対応で入れた「head と base が両方 draft パターンなら merge 許可」に regression があったため修正します。

## 問題

このエコシステムでは **2 稿目以降のレビュー PR 自体が draft→draft** です (例: head `2nd-draft` / base `1st-draft`、sotsuron-template の docs/CLAUDE-WORKFLOWS.md「各 draft PR は直前の draft をベースとする」)。このため PR #98 の条件では、2 稿目以降のレビュー PR (マージしてはいけない) まで `prevent-draft-merge` が許可してしまいます。abstract-1st のレビュー PR (base が最新 draft) も同様です。

## 修正内容

### `prevent-draft-merge.yml`

同期 PR とレビュー PR は**方向**で区別できます:

- 同期 PR: base が head の**次稿** (head `1st-draft` → base `2nd-draft`)
- レビュー PR: base が head の**前稿** (head `2nd-draft` → base `1st-draft`)

許可条件を「base が head の次稿と完全一致する場合」のみに限定しました (序数計算で next を求めて比較)。レビュー PR の方向・cross-series (abstract→Nth-draft 等) はすべてブロック継続です。

### `sync-next-draft.yml`

コンフリクト時のレビュー PR 特定を「base が draft パターンでない」から「**base ≠ 同期先ブランチ**」に戻しました。2 稿目以降のレビュー PR は base が draft のため、draft パターン除外では永遠に見つけられず通知が届かないためです。

## 検証観点

- head `1st-draft` / base `2nd-draft` (同期 PR) → 許可
- head `2nd-draft` / base `1st-draft` (レビュー PR) → ブロック
- head `abstract-1st` / base `5th-draft` (概要レビュー PR) → ブロック
- head `0th-draft` / base `1st-draft` (同期 PR) → 許可

merge 後は `v1.25.1` を発行し `v1` を付け替えます (非破壊のバグ修正)。

Refs: smkwlab/sotsuron-template#110, #98