### PR TITLE
feat: skip the PR build when only Markdown changed

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -37,8 +37,41 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # 2 so a pull request's merge commit brings both parents along:
+          # HEAD^1 (the base head) enables the changed-files diff below.
+          # Harmless for tag builds.
+          fetch-depth: 2
+
+      # Skip building pull requests whose changes cannot affect the PDFs
+      # (currently: every changed file is Markdown). The policy lives here in
+      # the reusable -- NOT as paths-ignore on the callers -- so that one
+      # place governs every repository (existing student repositories
+      # included, via the v1 moving tag) and so that it stays compatible with
+      # required status checks: a run whose build step is skipped still
+      # reports success, whereas a workflow filtered out by paths-ignore
+      # leaves a required check pending forever.
+      - name: Check whether the changes can affect the PDFs
+        id: relevance
+        if: github.event_name == 'pull_request'
+        run: |
+          # Fail open: when the diff cannot be computed, build.
+          if ! changed=$(git diff --name-only HEAD^1 HEAD --); then
+            echo "Could not determine changed files; building to be safe."
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          non_md=$(printf '%s\n' "$changed" | grep -v '\.md$' || true)
+          if [ -n "$non_md" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Only Markdown files changed; skipping the LaTeX build."
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build and Release LaTeX Documents
+        # Skip only on an explicit "false" (fail open on anything unexpected)
+        if: github.event_name != 'pull_request' || steps.relevance.outputs.build != 'false'
         uses: smkwlab/latex-release-action@v3.3.0
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## 概要

reusable の `latex-build.yml` に「PR の変更ファイルがすべて Markdown ならビルドステップを skip」する判定を追加します。

関連: smkwlab/latex-ecosystem#141

## なぜ caller の paths-ignore ではなく reusable 側か

| 観点 | paths-ignore（caller） | 本 PR（reusable 内 skip） |
|---|---|---|
| 適用範囲 | 再配布した repo のみ。既存学生リポジトリには届かない | **`v1` 移動タグで全 repo に即適用**（texlive イメージの一元 pin と同じ既存機構） |
| 将来の required checks | ワークフロー不起動 → 必須チェックが永久 pending | **skip されたステップでも run は success** |
| 除外方針の変更 | caller 再配布が毎回必要 | reusable 1 箇所 + リリース |
| caller の位置づけ | 配布物に方針が混入 | 配布物は薄いまま（派生モデルの原則どおり） |

## 実装

- `fetch-depth: 2` — PR の merge commit の両親を取得し、`HEAD^1`（base head）との diff で変更ファイル一覧を得る
- 判定は **fail open**: diff が取れない場合・非 Markdown ファイルが 1 つでもある場合はビルドする。skip は明示的な `build=false` のときだけ（ゲート条件も `!= 'false'`）
- タグ push は判定をバイパスして常にビルド（`submit` / `final-*` / `v*` のリリースフロー不変）

## 検証

- actionlint pass
- 判定ロジック（bash 部分）を 8 フィクスチャで単体検証: `.md` のみ（複数含む）→ skip、`.tex` / `.sty` / 画像 / `.latexmkrc` / `.md` と `.tex` の混在 / `note.md.tex` → build

## リリース

merge 後、SemVer（v1.26.0）でタグを打ち `v1` を移動すると、テンプレート・既存学生リポジトリの全 caller に適用されます。wr の `latex-build-modified`（push + paths フィルタ）と ise の `html-validation` は変更しません（判断の記録は smkwlab/latex-ecosystem#141）。
