### PR TITLE
fix: skip AI review and ML notification for dependency-bot PRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -64,7 +64,12 @@ jobs:
     # In a workflow_call, github.event is INHERITED from the caller's triggering
     # event, so for a pull_request caller this draft guard works as expected
     # (and is null -> skip for non-PR events).
-    if: github.event.pull_request.draft == false
+    # Dependency bumps carry no prose or design to review, and every run bills
+    # the model API, so dependency bots are skipped outright.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -39,8 +39,12 @@ permissions:
 
 jobs:
   notify-ml:
-    # Skip for draft PRs if configured
-    if: ${{ !inputs.skip-draft || !github.event.pull_request.draft }}
+    # Skip for draft PRs if configured, and always for dependency bots: their
+    # PRs would reach the lab mailing list as noise.
+    if: >-
+      (!inputs.skip-draft || !github.event.pull_request.draft) &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Resolves #108

## 背景

`ai-review.yml` と `notify-ml-on-pr.yml` は、PR の作成者が依存更新 bot でも通常の PR と同じように動いていた。

- `ai-review.yml` は Anthropic / Gemini の API を呼ぶので、**bot PR 1 本ごとに課金**が発生する。依存バージョンを上げただけの差分にレビューを走らせても得るものがない
- `notify-ml-on-pr.yml` は**研究室 ML にメールを送る**ため、bot の依存更新が学生・教員のメールボックスに届く

ise-report-template#98 で `.devcontainer` の npm 依存を Dependabot の追跡対象に加えるにあたり、同 repo の `ai-paper-review.yml` caller が追加されたのが 2026-06-09（直近の dependabot PR である 2025-11 より後）で、**npm dependabot を有効にすると月次 bot PR が AI レビュー課金と ML 通知を発火するのが初めて**になることが分かったため、先に塞ぐ。

## 変更内容

両 reusable の job-level `if` に bot ガードを追加した。

```yaml
# ai-review.yml
if: >-
  github.event.pull_request.draft == false &&
  github.actor != 'dependabot[bot]' &&
  github.actor != 'renovate[bot]'

# notify-ml-on-pr.yml
if: >-
  (!inputs.skip-draft || !github.event.pull_request.draft) &&
  github.actor != 'dependabot[bot]' &&
  github.actor != 'renovate[bot]'
```

### なぜ caller ではなく reusable か

caller テンプレート（`scripts/callers/`）を直す方式だと、反映に全対象 repo への `--update` 再配布が要る。reusable なら `v1`（可動メジャータグ）を進めるだけで既存の全 caller に届く。

### なぜ両方の bot か

reusable は org 全体に効くもので、org 内では 2 種類が動いている。

- **Renovate**: 本リポジトリ（#107 / #103 / #102 / #97 が `app/renovate`）
- **Dependabot**: ise-report-template（github-actions を月次で追跡、今回 npm を追加）

`workflow_call` では `github.event` も `github.actor` も caller の起動イベントを引き継ぐため、この判定は caller 側で PR イベントとして正しく効く（既存の draft ガードと同じ仕組み）。

## 検証

- `actionlint` 通過
- `notify-ml-on-pr.yml` は元が `${{ ... }}` 形式だったが、先頭が `(` になったため YAML タグとして解釈される問題は起きず、`>-` のブロックスカラーで記述できる（`!` 始まりを避ける必要があったのが元の `${{ }}` の理由）

## マージ後の作業

反映には **`v1` タグをマージコミットへ進める**必要がある（現在 716e6cc）。タグを動かすまで既存 caller の挙動は変わらない。

## 対象外

`create-next-draft.yml` は head ブランチ名が draft / abstract パターンかで既にガードされており bot PR では動かない。`sync-next-draft.yml` は push トリガ、`claude-qa.yml` は issue_comment トリガのため影響しない。